### PR TITLE
Fix for Unused local variable

### DIFF
--- a/middleware/harvester/tests/unit/test_main.py
+++ b/middleware/harvester/tests/unit/test_main.py
@@ -169,10 +169,6 @@ async def test_run_orchestrator_gathers_repositories_and_uses_expected_datasets(
     async def success_runner(_config: object) -> AsyncGenerator[str, None]:
         yield "arc-json"
 
-    async def failing_runner(_config: object) -> AsyncGenerator[str, None]:
-        raise RuntimeError("harvest failure")
-        yield  # pragma: no cover
-
     mock_client = _make_mock_client()
     expected_datasets = 10
     expected_harvest_calls = 2


### PR DESCRIPTION
The best fix is to delete the unused local async function `failing_runner` in `test_run_orchestrator_gathers_repositories_and_uses_expected_datasets`.  
This removes dead code and resolves the CodeQL finding without changing test logic or runtime behavior.

Specifically in `middleware/harvester/tests/unit/test_main.py`, remove the block:

- `async def failing_runner(_config: object) -> AsyncGenerator[str, None]:`
- `raise RuntimeError("harvest failure")`
- `yield  # pragma: no cover`

No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._