### PR TITLE
Fix for Unused local variable

### DIFF
--- a/middleware/harvester/tests/unit/test_main.py
+++ b/middleware/harvester/tests/unit/test_main.py
@@ -166,9 +166,6 @@ async def test_run_orchestrator_gathers_repositories_and_uses_expected_datasets(
     mock_config.repositories = repos
     mock_config.api_client = MagicMock()
 
-    async def success_runner(_config: object) -> AsyncGenerator[str, None]:
-        yield "arc-json"
-
     async def failing_runner(_config: object) -> AsyncGenerator[str, None]:
         raise RuntimeError("harvest failure")
         yield  # pragma: no cover


### PR DESCRIPTION
Remove the unused local async function `success_runner` from `test_run_orchestrator_gathers_repositories_and_uses_expected_datasets` in `middleware/harvester/tests/unit/test_main.py`.

Best fix without changing functionality:
- Delete only the unused function block:
  - `async def success_runner(_config: object) -> AsyncGenerator[str, None]:`
  - `yield "arc-json"`
- Keep all other logic intact, including `failing_runner`, plugin classes, assertions, and patches.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._