### PR TITLE
Fix pyOpenSSL DTLS cookie overflow CVE (Dependabot alert #11).

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
   "ggshield>=1.51.0",
   "cryptography>=46.0.6",
   "pyjwt>=2.12.0",
+  "pyopenssl>=26.0.0",
 ]
 
 [tool.uv.sources]
@@ -41,11 +42,12 @@ members = [
     "middleware/schema_org",
 ]
 
-# ggshield 1.51.0 pins cryptography~=43.0.1 and pyjwt~=2.6.0; override until upstream bumps.
+# ggshield 1.51.0 pins cryptography~=43.0.1 and pyjwt~=2.6.0; sigstore pulls pyopenssl<26; override until upstream bumps.
 [tool.uv]
 override-dependencies = [
   "cryptography>=46.0.6",
   "pyjwt>=2.12.0",
+  "pyopenssl>=26.0.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ members = [
 overrides = [
     { name = "cryptography", specifier = ">=46.0.6" },
     { name = "pyjwt", specifier = ">=2.12.0" },
+    { name = "pyopenssl", specifier = ">=26.0.0" },
 ]
 
 [[package]]
@@ -905,6 +906,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pyjwt" },
     { name = "pylint" },
+    { name = "pyopenssl" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -931,6 +933,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pylint", specifier = ">=4.0.4" },
+    { name = "pyopenssl", specifier = ">=26.0.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
@@ -1499,15 +1502,15 @@ wheels = [
 
 [[package]]
 name = "pyopenssl"
-version = "25.1.0"
+version = "26.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/8c/cd89ad05804f8e3c17dea8f178c3f40eeab5694c30e0c9f5bcd49f576fc3/pyopenssl-25.1.0.tar.gz", hash = "sha256:8d031884482e0c67ee92bf9a4d8cceb08d92aba7136432ffb0703c5280fc205b", size = 179937, upload-time = "2025-05-17T16:28:31.31Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/28/2659c02301b9500751f8d42f9a6632e1508aa5120de5e43042b8b30f8d5d/pyopenssl-25.1.0-py3-none-any.whl", hash = "sha256:2b11f239acc47ac2e5aca04fd7fa829800aeee22a2eb30d744572a157bd8a1ab", size = 56771, upload-time = "2025-05-17T16:28:29.197Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Override transitive pyopenssl to >=26.0.0 (via ggshield/sigstore chain).