### PR TITLE
Fix python-dotenv symlink overwrite CVE (Dependabot alert #13).

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
   "cryptography>=46.0.6",
   "pyjwt>=2.12.0",
   "pyopenssl>=26.0.0",
+  "python-dotenv>=1.2.2",
 ]
 
 [tool.uv.sources]
@@ -42,12 +43,13 @@ members = [
     "middleware/schema_org",
 ]
 
-# ggshield 1.51.0 pins cryptography~=43.0.1 and pyjwt~=2.6.0; sigstore pulls pyopenssl<26; override until upstream bumps.
+# ggshield 1.51.0 pins old transitive deps; override until upstream bumps.
 [tool.uv]
 override-dependencies = [
   "cryptography>=46.0.6",
   "pyjwt>=2.12.0",
   "pyopenssl>=26.0.0",
+  "python-dotenv>=1.2.2",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,7 @@ overrides = [
     { name = "cryptography", specifier = ">=46.0.6" },
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pyopenssl", specifier = ">=26.0.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
 
 [[package]]
@@ -912,6 +913,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-mock" },
+    { name = "python-dotenv" },
     { name = "respx" },
     { name = "ruff" },
 ]
@@ -939,6 +941,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-env", specifier = ">=1.2.0" },
     { name = "pytest-mock", specifier = ">=3.10.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "respx", specifier = ">=0.23.1" },
     { name = "ruff", specifier = ">=0.15.16" },
 ]
@@ -1616,11 +1619,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "0.21.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/d7/d548e0d5a68b328a8d69af833a861be415a17cb15ce3d8f0cd850073d2e1/python-dotenv-0.21.1.tar.gz", hash = "sha256:1c93de8f636cde3ce377292818d0e440b6e45a82f215c3744979151fa8151c49", size = 35930, upload-time = "2023-01-21T10:22:47.277Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/62/f19d1e9023aacb47241de3ab5a5d5fedf32c78a71a9e365bb2153378c141/python_dotenv-0.21.1-py3-none-any.whl", hash = "sha256:41e12e0318bebc859fcc4d97d4db8d20ad21721a6aa5047dd59f090391cb549a", size = 19284, upload-time = "2023-01-21T10:22:45.958Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Override ggshield's python-dotenv~=0.21.0 pin to >=1.2.2.