### PR TITLE
Update Dockerfile.harvester to ensure compatibility with OpenSSL libr…

### DIFF
--- a/docker/Dockerfile.harvester
+++ b/docker/Dockerfile.harvester
@@ -21,11 +21,15 @@ RUN uv build --package inspire --wheel && uv build --package harvester --wheel &
 # ---- Binary Build Stage ----
 FROM python:3.12.13-alpine3.23 AS binary-builder
 
-# Install build tools for PyInstaller
+# Install build tools for PyInstaller.
+# libcrypto3/libssl3 must match openssl-dev: the python base image ships older
+# runtime libs (3.5.6) while Alpine main may only offer openssl-dev 3.5.7+.
 RUN apk add --no-cache \
     build-base=0.5-r3 \
     python3-dev=3.12.13-r0 \
     libffi-dev=3.5.2-r0 \
+    libcrypto3=3.5.7-r0 \
+    libssl3=3.5.7-r0 \
     openssl-dev=3.5.7-r0 \
     cargo=1.91.1-r2 \
     git=2.52.0-r0


### PR DESCRIPTION
…aries

- Added specific versions for libcrypto3 and libssl3 to match openssl-dev, addressing compatibility issues with the Python base image.
- Enhanced comments for clarity regarding the installation of build tools for PyInstaller.