### PR TITLE
Enhance XML query handling in CSWClient for pagination and record limits

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,15 +22,20 @@
   },
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
 
-  // Mypy — .venv binary from `uv sync`, config in pyproject.toml [tool.mypy]
+  // Mypy — project type gate (identical to pre-commit / CI):
+  //   uv run mypy --config-file pyproject.toml middleware/
+  // reportingScope=workspace: Problems must list the same diagnostics as CI, not
+  // only the active editor. cursorpyright/Pylance are NOT the merge gate.
   "mypy-type-checker.importStrategy": "fromEnvironment",
   "mypy-type-checker.path": ["${workspaceFolder}/.venv/bin/mypy"],
+  "mypy-type-checker.interpreter": ["${workspaceFolder}/.venv/bin/python"],
+  "mypy-type-checker.cwd": "${workspaceFolder}",
+  "mypy-type-checker.reportingScope": "workspace",
+  "mypy-type-checker.preferDaemon": false,
   "mypy-type-checker.args": [
-    "--config-file",
-    "${workspaceFolder}/pyproject.toml",
+    "--config-file=${workspaceFolder}/pyproject.toml",
     "${workspaceFolder}/middleware"
   ],
-  "mypy-type-checker.preferDaemon": false,
 
   // Ruff: same binary as `uv run ruff` / pre-commit (project .venv).
   // ruff.path must be ruff executables only — NOT ["uv","run","ruff"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ uv run pytest middleware/ -v
 # Quality checks (all read config from pyproject.toml — see spec/principles.md)
 uv run ruff format --check middleware/
 uv run ruff check middleware/
-uv run mypy middleware/
+uv run mypy --config-file pyproject.toml middleware/
 uv run pylint middleware/
 uv run bandit -r middleware/ -c .bandit -ll
 

--- a/dev_environment/config.yaml
+++ b/dev_environment/config.yaml
@@ -21,6 +21,8 @@ repositories:
 #       # CSW-Abfrage nach DWD Datensaetzen. Die Zahl der Treffer unterscheidet sich von der
 #       # Web-GUI (https://www.geoportal.de/search.html?q=Deutscher%20Wetterdienst,
 #       # https://www.geoportal.de/search.html?q=DWD)
+#       # Optional: XML maxRecords / startPosition override chunk_size / initial offset.
+#       # Harvest-wide test limit: max_records (config), not CSW maxRecords.
 #       xml_query: |
 #         <?xml version="1.0" encoding="UTF-8"?>
 #         <csw:GetRecords
@@ -30,9 +32,7 @@ repositories:
 #             version="2.0.2"
 #             resultType="results"
 #             outputFormat="application/xml"
-#             outputSchema="http://www.isotc211.org/2005/gmd"
-#             startPosition="1"
-#             maxRecords="50">
+#             outputSchema="http://www.isotc211.org/2005/gmd">
 
 #           <csw:Query typeNames="csw:Record">
 #             <csw:ElementSetName>summary</csw:ElementSetName>

--- a/dev_environment/config_example.yaml
+++ b/dev_environment/config_example.yaml
@@ -52,6 +52,10 @@ repositories:
 #       # CSW-Abfrage nach DWD Datensaetzen. Die Zahl der Treffer unterscheidet sich von der
 #       # Web-GUI (https://www.geoportal.de/search.html?q=Deutscher%20Wetterdienst,
 #       # https://www.geoportal.de/search.html?q=DWD)
+#       # Optional: XML maxRecords / startPosition override chunk_size / initial offset.
+#       # Harvest-wide test limit: max_records (config), not CSW maxRecords.
+#       # chunk_size: 50
+#       # max_records: 10
 #       xml_query: |
 #         <?xml version="1.0" encoding="UTF-8"?>
 #         <csw:GetRecords
@@ -61,9 +65,7 @@ repositories:
 #             version="2.0.2"
 #             resultType="results"
 #             outputFormat="application/xml"
-#             outputSchema="http://www.isotc211.org/2005/gmd"
-#             startPosition="1"
-#             maxRecords="50">
+#             outputSchema="http://www.isotc211.org/2005/gmd">
 
 #           <csw:Query typeNames="csw:Record">
 #             <csw:ElementSetName>summary</csw:ElementSetName>

--- a/middleware/inspire/README.md
+++ b/middleware/inspire/README.md
@@ -25,10 +25,10 @@ The plugin is configured as part of a `repository` entry in the central Harveste
 | :--- | :--- | :--- | :--- |
 | `csw_url` | string | *(required)* | Base URL of the CSW 2.0.2 endpoint. |
 | `cql_query` | string | `None` | OGC CQL filter (e.g., `AnyText LIKE '%agriculture%'`). |
-| `xml_query` | string | `None` | Raw XML body for `GetRecords` (mutually exclusive with `cql_query`). |
-| `chunk_size` | int | `50` | Number of records to fetch per paginated request. |
+| `xml_query` | string | `None` | Raw `GetRecords` XML body (mutually exclusive with `cql_query`). Paginated: filter body is preserved; `startPosition`/`maxRecords` are rewritten per page. |
+| `chunk_size` | int | `50` | Records per paginated request. Overridden by a valid XML `maxRecords` when using `xml_query`. |
 | `timeout` | int | `30` | Network timeout for CSW requests in seconds. |
-| `max_records` | int | `None` | Debug limit: stop after N records (set to `None` for all). |
+| `max_records` | int | `None` | Harvest-wide debug limit: stop after N records across all pages (`None` = all). Do not use XML `maxRecords` for this. |
 
 ### Example Plugin Configuration
 

--- a/middleware/inspire/spec/csw-harvesting/design.md
+++ b/middleware/inspire/spec/csw-harvesting/design.md
@@ -35,3 +35,5 @@
    only N for a test run”. Dublin Core identifier fallback for broken ISO
    batches deep-copies the template, switches `outputSchema` to CSW/DC and
    `ElementSetName` to `brief`, then applies the same paging attributes.
+   Non-ISO `outputSchema` on the template is overridden to ISO 19139 for the
+   primary fetch (with a warning), matching `_fetch_iso_batch`.

--- a/middleware/inspire/spec/csw-harvesting/design.md
+++ b/middleware/inspire/spec/csw-harvesting/design.md
@@ -26,14 +26,14 @@
    — Operators need complex FES filters that are awkward as CQL. Passing a
    full `GetRecords` document used to be a single unpaged call, so omitting
    `maxRecords` silently harvested only the server default page (often 10).
-   The XML filter/query body stays intact; each page sets `startPosition` and
-   `maxRecords` on the `GetRecords` root. Page size defaults to config
-   `chunk_size`; a valid XML `maxRecords` overrides page size only (same role
-   as Solr `rows` / Regal `until` in linked_data). A valid XML `startPosition`
-   overrides the initial offset. Harvest-wide caps use config `max_records`
-   so operators are not forced to overload CSW `maxRecords` for “download
-   only N for a test run”. Dublin Core identifier fallback for broken ISO
-   batches deep-copies the template, switches `outputSchema` to CSW/DC and
+   The XML filter/query body stays intact; each page deep-copies the template
+   and sets `startPosition` / `maxRecords` on that copy only. Page size defaults
+   to config `chunk_size`; a valid XML `maxRecords` overrides page size only
+   (same role as Solr `rows` / Regal `until` in linked_data). A valid XML
+   `startPosition` overrides the initial offset. Harvest-wide caps use config
+   `max_records` so operators are not forced to overload CSW `maxRecords` for
+   “download only N for a test run”. Dublin Core identifier fallback for broken
+   ISO batches deep-copies the template, switches `outputSchema` to CSW/DC and
    `ElementSetName` to `brief`, then applies the same paging attributes.
-   Non-ISO `outputSchema` on the template is overridden to ISO 19139 for the
-   primary fetch (with a warning), matching `_fetch_iso_batch`.
+   Non-ISO `outputSchema` on the template is overridden to ISO 19139 on each
+   ISO request copy (warned once at prepare), matching `_fetch_iso_batch`.

--- a/middleware/inspire/spec/csw-harvesting/design.md
+++ b/middleware/inspire/spec/csw-harvesting/design.md
@@ -37,3 +37,6 @@
    `ElementSetName` to `brief`, then applies the same paging attributes.
    Non-ISO `outputSchema` on the template is overridden to ISO 19139 on each
    ISO request copy (warned once at prepare), matching `_fetch_iso_batch`.
+   GetRecords structure is validated via `_prepare_xml_query_before_network`
+   in `get_records` / `get_records_async` / `get_record_count` **before**
+   `connect()`, so invalid XML never triggers a CSW network call.

--- a/middleware/inspire/spec/csw-harvesting/design.md
+++ b/middleware/inspire/spec/csw-harvesting/design.md
@@ -21,3 +21,17 @@
    Termination uses `start_position > matches` (not `>=`): position `matches`
    is still valid. If pagination does not advance past the current start,
    it stops with a warning to avoid an infinite loop on broken servers.
+
+5. **`xml_query` reuses the same pagination loop; only paging attrs are rewritten**
+   — Operators need complex FES filters that are awkward as CQL. Passing a
+   full `GetRecords` document used to be a single unpaged call, so omitting
+   `maxRecords` silently harvested only the server default page (often 10).
+   The XML filter/query body stays intact; each page sets `startPosition` and
+   `maxRecords` on the `GetRecords` root. Page size defaults to config
+   `chunk_size`; a valid XML `maxRecords` overrides page size only (same role
+   as Solr `rows` / Regal `until` in linked_data). A valid XML `startPosition`
+   overrides the initial offset. Harvest-wide caps use config `max_records`
+   so operators are not forced to overload CSW `maxRecords` for “download
+   only N for a test run”. Dublin Core identifier fallback for broken ISO
+   batches deep-copies the template, switches `outputSchema` to CSW/DC and
+   `ElementSetName` to `brief`, then applies the same paging attributes.

--- a/middleware/inspire/spec/csw-harvesting/spec.md
+++ b/middleware/inspire/spec/csw-harvesting/spec.md
@@ -9,7 +9,10 @@ Query the Catalogue Service for Web (CSW) endpoints and parse ISO 19139 XML into
   - **standard** — no filter; paginated fetch of all records.
   - **cql_query** — CQL text filter (e.g. `AnyText LIKE '%agriculture%'`); paginated.
   - **fes_constraints** — list of OWSLib `OgcExpression` objects; paginated.
-  - **xml_query** — raw `GetRecords` XML body passed through verbatim; no pagination.
+  - **xml_query** — raw `GetRecords` XML body; paginated like the other modes (filter/query body preserved; paging attributes rewritten per page).
+- [ ] For `xml_query` pagination, use config `chunk_size` as the page size unless the XML root specifies a valid `maxRecords` (> 0), which overrides `chunk_size` for the page size only.
+- [ ] For `xml_query` pagination, start at position 1 unless the XML root specifies a valid `startPosition` (≥ 1), which is the initial page offset.
+- [ ] Cap the total number of harvested records with config `max_records` when set (all query modes); do not treat XML `maxRecords` as a harvest-wide limit.
 - [ ] Enforce mutual exclusion: activating more than one query mode (combining call-site arguments with Config defaults) must raise `ValueError` immediately, before any network call.
 - [ ] Parse each ISO 19139 batch and yield `RecordProcessingError` for every record whose XML cannot be parsed, using the ISO identifier where available.
 - [ ] If and only if a batch contains ISO records without a usable identifier (absent or `owslib_random_*`), fetch the corresponding Dublin Core batch to obtain stable identifiers for those records.
@@ -24,3 +27,7 @@ Query the Catalogue Service for Web (CSW) endpoints and parse ISO 19139 XML into
 - Broken XML responses or invalid attribute access → yield `RecordProcessingError`, continue iteration.
 - `fes_constraints` has no Config-level equivalent because OWSLib `OgcExpression` objects are runtime-only and not YAML-serializable; it can only be supplied at call time.
 - An XML query with an encoding declaration must be converted to `bytes` before being passed to OWSLib to avoid an lxml `Unicode strings with encoding declaration` error.
+- `xml_query` whose root is not `GetRecords` (CSW 2.0.2) → raise `ValueError` before any network call.
+- `xml_query` with invalid / non-positive `maxRecords` or `startPosition` → ignore that attribute, log a warning, and fall back to config / default (same as if omitted).
+- `xml_query` plus config `max_records=N` → stop after N successfully counted records across pages (same semantics as CQL/standard).
+- Operator sets XML `maxRecords="10"` and config `chunk_size=50` → each page requests 10 records; harvest continues across pages until exhausted or `max_records` stops it.

--- a/middleware/inspire/spec/csw-harvesting/spec.md
+++ b/middleware/inspire/spec/csw-harvesting/spec.md
@@ -31,4 +31,4 @@ Query the Catalogue Service for Web (CSW) endpoints and parse ISO 19139 XML into
 - `xml_query` with invalid / non-positive `maxRecords` or `startPosition` → ignore that attribute, log a warning, and fall back to config / default (same as if omitted).
 - `xml_query` plus config `max_records=N` → stop after N successfully counted records across pages (same semantics as CQL/standard); the final page is truncated so the yield count does not exceed N.
 - Operator sets XML `maxRecords="10"` and config `chunk_size=50` → each page requests 10 records; harvest continues across pages until exhausted or `max_records` stops it.
-- `xml_query` with a non-ISO `outputSchema` → override to ISO 19139 (`gmd`) for the harvest fetch (with a warning); Dublin Core fallback still switches schema on a copy.
+- `xml_query` with a non-ISO `outputSchema` → override to ISO 19139 (`gmd`) on each ISO request copy (warned once at prepare); the shared template is not mutated; Dublin Core fallback still switches schema on its own copy.

--- a/middleware/inspire/spec/csw-harvesting/spec.md
+++ b/middleware/inspire/spec/csw-harvesting/spec.md
@@ -31,3 +31,4 @@ Query the Catalogue Service for Web (CSW) endpoints and parse ISO 19139 XML into
 - `xml_query` with invalid / non-positive `maxRecords` or `startPosition` → ignore that attribute, log a warning, and fall back to config / default (same as if omitted).
 - `xml_query` plus config `max_records=N` → stop after N successfully counted records across pages (same semantics as CQL/standard).
 - Operator sets XML `maxRecords="10"` and config `chunk_size=50` → each page requests 10 records; harvest continues across pages until exhausted or `max_records` stops it.
+- `xml_query` with a non-ISO `outputSchema` → override to ISO 19139 (`gmd`) for the harvest fetch (with a warning); Dublin Core fallback still switches schema on a copy.

--- a/middleware/inspire/spec/csw-harvesting/spec.md
+++ b/middleware/inspire/spec/csw-harvesting/spec.md
@@ -27,7 +27,7 @@ Query the Catalogue Service for Web (CSW) endpoints and parse ISO 19139 XML into
 - Broken XML responses or invalid attribute access → yield `RecordProcessingError`, continue iteration.
 - `fes_constraints` has no Config-level equivalent because OWSLib `OgcExpression` objects are runtime-only and not YAML-serializable; it can only be supplied at call time.
 - An XML query with an encoding declaration must be converted to `bytes` before being passed to OWSLib to avoid an lxml `Unicode strings with encoding declaration` error.
-- `xml_query` whose root is not CSW 2.0.2 `GetRecords` (wrong element, nested, or non-CSW namespace) → raise `ValueError` before any network call.
+- `xml_query` whose root is not CSW 2.0.2 `GetRecords` in the CSW namespace (wrong element, nested, unnamespaced, or non-CSW namespace) → raise `ValueError` before any network call.
 - `xml_query` with invalid / non-positive `maxRecords` or `startPosition` → ignore that attribute, log a warning, and fall back to config / default (same as if omitted).
 - `xml_query` plus config `max_records=N` → stop after N successfully counted records across pages (same semantics as CQL/standard); the final page is truncated so the yield count does not exceed N.
 - Operator sets XML `maxRecords="10"` and config `chunk_size=50` → each page requests 10 records; harvest continues across pages until exhausted or `max_records` stops it.

--- a/middleware/inspire/spec/csw-harvesting/spec.md
+++ b/middleware/inspire/spec/csw-harvesting/spec.md
@@ -29,6 +29,6 @@ Query the Catalogue Service for Web (CSW) endpoints and parse ISO 19139 XML into
 - An XML query with an encoding declaration must be converted to `bytes` before being passed to OWSLib to avoid an lxml `Unicode strings with encoding declaration` error.
 - `xml_query` whose root is not CSW 2.0.2 `GetRecords` in the CSW namespace (wrong element, nested, unnamespaced, or non-CSW namespace) → raise `ValueError` before any network call.
 - `xml_query` with invalid / non-positive `maxRecords` or `startPosition` → ignore that attribute, log a warning, and fall back to config / default (same as if omitted).
-- `xml_query` plus config `max_records=N` → stop after N successfully counted records across pages (same semantics as CQL/standard); the final page is truncated so the yield count does not exceed N.
+- `xml_query` plus config `max_records=N` → stop after N successfully counted records across pages (same semantics as CQL/standard); the final page is truncated so the success yield count does not exceed N, while `RecordProcessingError` items from that page are still yielded.
 - Operator sets XML `maxRecords="10"` and config `chunk_size=50` → each page requests 10 records; harvest continues across pages until exhausted or `max_records` stops it.
 - `xml_query` with a non-ISO `outputSchema` → override to ISO 19139 (`gmd`) on each ISO request copy (warned once at prepare); the shared template is not mutated; Dublin Core fallback still switches schema on its own copy.

--- a/middleware/inspire/spec/csw-harvesting/spec.md
+++ b/middleware/inspire/spec/csw-harvesting/spec.md
@@ -27,8 +27,8 @@ Query the Catalogue Service for Web (CSW) endpoints and parse ISO 19139 XML into
 - Broken XML responses or invalid attribute access → yield `RecordProcessingError`, continue iteration.
 - `fes_constraints` has no Config-level equivalent because OWSLib `OgcExpression` objects are runtime-only and not YAML-serializable; it can only be supplied at call time.
 - An XML query with an encoding declaration must be converted to `bytes` before being passed to OWSLib to avoid an lxml `Unicode strings with encoding declaration` error.
-- `xml_query` whose root is not `GetRecords` (CSW 2.0.2) → raise `ValueError` before any network call.
+- `xml_query` whose root is not CSW 2.0.2 `GetRecords` (wrong element, nested, or non-CSW namespace) → raise `ValueError` before any network call.
 - `xml_query` with invalid / non-positive `maxRecords` or `startPosition` → ignore that attribute, log a warning, and fall back to config / default (same as if omitted).
-- `xml_query` plus config `max_records=N` → stop after N successfully counted records across pages (same semantics as CQL/standard).
+- `xml_query` plus config `max_records=N` → stop after N successfully counted records across pages (same semantics as CQL/standard); the final page is truncated so the yield count does not exceed N.
 - Operator sets XML `maxRecords="10"` and config `chunk_size=50` → each page requests 10 records; harvest continues across pages until exhausted or `max_records` stops it.
 - `xml_query` with a non-ISO `outputSchema` → override to ISO 19139 (`gmd`) for the harvest fetch (with a warning); Dublin Core fallback still switches schema on a copy.

--- a/middleware/inspire/src/middleware/inspire/config.py
+++ b/middleware/inspire/src/middleware/inspire/config.py
@@ -19,16 +19,34 @@ class Config(BaseModel):
     ] = None
     xml_query: Annotated[
         str | None,
-        Field(alias="xml_request", description="Raw GetRecords XML body (overrides cql_query)"),
+        Field(
+            alias="xml_request",
+            description=(
+                "Raw GetRecords XML body (overrides cql_query). Paginated: filter preserved; "
+                "startPosition/maxRecords rewritten per page. XML maxRecords overrides chunk_size; "
+                "XML startPosition overrides the initial offset. Use config max_records to cap total."
+            ),
+        ),
     ] = None
     chunk_size: Annotated[
         int,
-        Field(description="Number of records to fetch per paginated request.", ge=1),
+        Field(
+            description=(
+                "Number of records to fetch per paginated CSW request. "
+                "For xml_query, a valid GetRecords maxRecords attribute overrides this page size."
+            ),
+            ge=1,
+        ),
     ] = 50
 
     max_records: Annotated[
         int | None,
-        Field(description="Maximum number of records to harvest (None = all records). Debug option."),
+        Field(
+            description=(
+                "Maximum number of records to harvest across all pages (None = all records). "
+                "Debug/test limit for every query mode; not the CSW per-request maxRecords page size."
+            ),
+        ),
     ] = None
 
     timeout: Annotated[

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -564,12 +564,13 @@ class CSWClient:
         batch_size: int,
         start_position: int,
         as_bytes: bool,
-        swallow_errors: bool = True,
     ) -> bool:
         """Fetch one ISO page without mutating the shared xml_query template.
 
         Paging attributes and ISO ``outputSchema`` are applied on a deep copy so the
         operator template (filter body and original attributes) stays intact across pages.
+        Transient fetch failures are logged and return False so pagination can stop without
+        aborting the generator.
         """
         if self._csw is None:
             self.connect()
@@ -586,10 +587,8 @@ class CSWClient:
             self._csw.getrecords2(xml=self._serialize_xml_query(request_root, as_bytes))
             return True
         except (OSError, TimeoutError, ValueError) as e:
-            if swallow_errors:
-                logger.error("Failed to fetch ISO records from CSW at position %d: %s", start_position, e)
-                raise CswConnectionError(f"Failed to fetch ISO records from CSW: {e}") from e
-            raise
+            logger.error("Failed to fetch ISO records from CSW at position %d: %s", start_position, e)
+            return False
 
     def _fetch_dc_ids_xml(
         self,
@@ -749,9 +748,12 @@ class CSWClient:
         start_position: int,
         cql_query: str | None,
         fes_constraints: list[OgcExpression] | None,
-        swallow_errors: bool = True,
     ) -> bool:
-        """Fetch a batch of records in ISO 19139 format."""
+        """Fetch a batch of records in ISO 19139 format.
+
+        Transient fetch failures are logged and return False so pagination can stop without
+        aborting the generator.
+        """
         if self._csw is None:
             self.connect()
         if self._csw is None:
@@ -771,16 +773,9 @@ class CSWClient:
             else:
                 self._csw.getrecords2(**kwargs)
             return True
-        except (OSError, TimeoutError) as e:
-            if swallow_errors:
-                logger.error("Failed to fetch ISO records from CSW at position %d: %s", start_position, e)
-                raise CswConnectionError(f"Failed to fetch ISO records from CSW: {e}") from e
-            raise
-        except ValueError as e:
-            if swallow_errors:
-                logger.error("Failed to fetch ISO records from CSW at position %d: %s", start_position, e)
-                raise CswConnectionError(f"Failed to fetch ISO records from CSW: {e}") from e
-            raise
+        except (OSError, TimeoutError, ValueError) as e:
+            logger.error("Failed to fetch ISO records from CSW at position %d: %s", start_position, e)
+            return False
 
     def _yield_iso_records(self) -> Iterator[InspireRecord | RecordProcessingError]:
         """Yield parsed ISO records from the last-fetched batch (ISO-first, no DC involved)."""

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -538,8 +538,9 @@ class CSWClient:
     def _find_get_records_element(root: lxml.etree._Element) -> lxml.etree._Element | None:
         """Return *root* when it is a CSW 2.0.2 GetRecords element; otherwise None.
 
-        Only the document root is accepted, and it must be in the CSW 2.0.2 namespace
-        (not unnamespaced ``GetRecords`` or an arbitrary ``*:GetRecords``).
+        Only the document root is accepted. The element must expand to the CSW 2.0.2
+        namespace (any prefix or default xmlns is fine); unnamespaced ``GetRecords``
+        and GetRecords in any other namespace are rejected.
         """
         if root.tag == _CSW_GET_RECORDS_TAG:
             return root

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -379,6 +379,10 @@ class CSWClient:
                 break
 
             results, count = page
+            results, count = self._limit_page_to_max_records(results, count, records_yielded, max_records)
+            if not results:
+                break
+
             yield from results
             records_yielded += count
 
@@ -389,6 +393,36 @@ class CSWClient:
             if next_start is None:
                 break
             start_position = next_start
+
+    @staticmethod
+    def _limit_page_to_max_records(
+        results: list[InspireRecord | RecordProcessingError],
+        count: int,
+        records_yielded: int,
+        max_records: int | None,
+    ) -> tuple[list[InspireRecord | RecordProcessingError], int]:
+        """Trim a page so successful records do not exceed the remaining max_records budget."""
+        if max_records is None:
+            return results, count
+        remaining = max_records - records_yielded
+        if remaining <= 0:
+            return [], 0
+        if count <= remaining:
+            return results, count
+
+        limited: list[InspireRecord | RecordProcessingError] = []
+        successes = 0
+        for item in results:
+            if isinstance(item, RecordProcessingError):
+                if successes >= remaining:
+                    break
+                limited.append(item)
+                continue
+            if successes >= remaining:
+                break
+            limited.append(item)
+            successes += 1
+        return limited, successes
 
     def _fetch_and_parse_page(
         self,
@@ -488,14 +522,12 @@ class CSWClient:
 
     @staticmethod
     def _find_get_records_element(root: lxml.etree._Element) -> lxml.etree._Element | None:
-        """Return *root* when it is a CSW GetRecords element; otherwise None.
+        """Return *root* when it is a CSW 2.0.2 GetRecords element; otherwise None.
 
-        Only the document root is accepted (no descendant lookup), matching the
-        xml_query contract and keeping namespace declarations on the serialized body.
+        Only the document root is accepted, and only unnamespaced ``GetRecords`` or the
+        CSW 2.0.2 namespace — not an arbitrary ``*:GetRecords``.
         """
         if root.tag in _CSW_GET_RECORDS_TAGS:
-            return root
-        if isinstance(root.tag, str) and lxml.etree.QName(root).localname == "GetRecords":
             return root
         return None
 

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -321,8 +321,8 @@ class CSWClient:
     def _get_records_by_xml(
         self, xml_query: str | bytes, chunk_size: int, max_records: int | None
     ) -> Iterator[InspireRecord | RecordProcessingError]:
-        """Retrieve records using a raw XML GetRecords body with pagination."""
-        logger.info("Using raw XML request for harvesting.")
+        """Retrieve records using a GetRecords XML body with pagination."""
+        logger.info("Using XML GetRecords request for harvesting (paginated).")
         yield from self._get_records_paged(chunk_size, None, None, max_records, xml_query=xml_query)
 
     def _get_records_by_fes(

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -379,6 +379,7 @@ class CSWClient:
                 break
 
             results, count = page
+            fetched_batch_size = len(results)
             results, count = self._limit_page_to_max_records(results, count, records_yielded, max_records)
             if not results:
                 break
@@ -389,7 +390,9 @@ class CSWClient:
             if max_records is not None and records_yielded >= max_records:
                 break
 
-            next_start = self._advance_start_position(start_position, records_in_batch=len(results))
+            # Use the fetched page size, not a max_records-trimmed yield list, so the
+            # missing-nextrecord/returned fallback advances by the real CSW batch length.
+            next_start = self._advance_start_position(start_position, records_in_batch=fetched_batch_size)
             if next_start is None:
                 break
             start_position = next_start
@@ -401,7 +404,11 @@ class CSWClient:
         records_yielded: int,
         max_records: int | None,
     ) -> tuple[list[InspireRecord | RecordProcessingError], int]:
-        """Trim a page so successful records do not exceed the remaining max_records budget."""
+        """Trim a page so successful records do not exceed the remaining max_records budget.
+
+        ``RecordProcessingError`` items are never capped: every error from the fetched page
+        is kept so data-quality failures remain visible even when the success budget is full.
+        """
         if max_records is None:
             return results, count
         remaining = max_records - records_yielded
@@ -414,12 +421,10 @@ class CSWClient:
         successes = 0
         for item in results:
             if isinstance(item, RecordProcessingError):
-                if successes >= remaining:
-                    break
                 limited.append(item)
                 continue
             if successes >= remaining:
-                break
+                continue
             limited.append(item)
             successes += 1
         return limited, successes

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import copy
 import logging
 import random
 from collections.abc import AsyncGenerator, Callable, Iterator
@@ -25,6 +26,11 @@ from .models import InspireRecord
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
+
+_CSW_NS = "http://www.opengis.net/cat/csw/2.0.2"
+_CSW_GET_RECORDS_TAGS = frozenset({"GetRecords", f"{{{_CSW_NS}}}GetRecords"})
+_ISO_OUTPUT_SCHEMA = "http://www.isotc211.org/2005/gmd"
+_DC_OUTPUT_SCHEMA = "http://www.opengis.net/cat/csw/2.0.2"
 
 
 class CSWClient:
@@ -186,7 +192,7 @@ class CSWClient:
         """Retrieve records from the CSW, yielding InspireRecord or RecordProcessingError objects.
 
         Exactly one filter mode may be active at a time (including values inherited from Config):
-          - xml_query       — raw GetRecords XML; no pagination
+          - xml_query       — raw GetRecords XML; paginated (paging attrs rewritten per page)
           - fes_constraints — OWSLib FES constraint objects; paginated
           - cql_query       — CQL text query string; paginated
           - (none)          — fetch all records; paginated
@@ -196,6 +202,9 @@ class CSWClient:
 
         Explicit arguments override the corresponding Config fields.
         chunk_size and max_records fall back to Config values when not provided.
+        For ``xml_query``, a valid XML ``maxRecords`` overrides page size (chunk_size);
+        a valid XML ``startPosition`` overrides the initial offset. Config ``max_records``
+        remains the harvest-wide cap for all modes.
 
         Args:
             cql_query: CQL filter string, e.g. "AnyText LIKE '%agriculture%'". Overrides
@@ -218,7 +227,7 @@ class CSWClient:
             raise RuntimeError("CSW client is not initialized.")
 
         if effective_xml is not None:
-            yield from self._get_records_by_xml(effective_xml)
+            yield from self._get_records_by_xml(effective_xml, effective_chunk_size, effective_max_records)
         elif effective_fes is not None:
             yield from self._get_records_by_fes(effective_fes, effective_chunk_size, effective_max_records)
         elif effective_cql is not None:
@@ -261,7 +270,11 @@ class CSWClient:
     ) -> tuple[str, Callable[..., Iterator[InspireRecord | RecordProcessingError]], tuple[object, ...]]:
         """Return (strategy_name, callable, args) for the active filter mode."""
         if effective_xml:
-            return "get_records_by_xml", self._get_records_by_xml, (effective_xml,)
+            return (
+                "get_records_by_xml",
+                self._get_records_by_xml,
+                (effective_xml, effective_chunk_size, effective_max_records),
+            )
         if effective_fes:
             return (
                 "get_records_by_fes",
@@ -305,25 +318,12 @@ class CSWClient:
             return xml_query.encode("utf-8")
         return xml_query
 
-    def _get_records_by_xml(self, xml_query: str | bytes) -> Iterator[InspireRecord | RecordProcessingError]:
-        """Retrieve records using a raw XML request."""
+    def _get_records_by_xml(
+        self, xml_query: str | bytes, chunk_size: int, max_records: int | None
+    ) -> Iterator[InspireRecord | RecordProcessingError]:
+        """Retrieve records using a raw XML GetRecords body with pagination."""
         logger.info("Using raw XML request for harvesting.")
-        if self._csw is None:
-            self.connect()
-        if self._csw is None:
-            raise RuntimeError("CSW client is not initialized.")
-
-        xml_query = self._normalize_xml_query(xml_query)
-
-        self._csw.getrecords2(xml=xml_query)
-        if self._csw.records:
-            for uuid, record in self._csw.records.items():
-                if isinstance(record, MD_Metadata):
-                    try:
-                        yield self._parse_iso_record(record, record_uuid=uuid)
-                    except Exception as e:  # noqa: BLE001
-                        # We yield instead of raising to allow the generator to continue
-                        yield RecordProcessingError(str(e), uuid, original_error=e)
+        yield from self._get_records_paged(chunk_size, None, None, max_records, xml_query=xml_query)
 
     def _get_records_by_fes(
         self, fes_constraints: list[OgcExpression], chunk_size: int, max_records: int | None
@@ -344,50 +344,231 @@ class CSWClient:
         cql_query: str | None,
         fes_constraints: list[OgcExpression] | None,
         max_records: int | None,
+        xml_query: str | bytes | None = None,
     ) -> Iterator[InspireRecord | RecordProcessingError]:
         """Retrieve all records using pagination, fetching chunk_size records per request.
 
         CSW 2.0.2 ``startPosition`` is 1-based. Starting at 0 (OWSLib default) makes
         servers treat the first page as position 1, then ``start += page_size`` requests
         position ``page_size`` again and duplicates one record per page boundary.
+
+        When ``xml_query`` is set, the GetRecords filter body is preserved and only
+        paging attributes are rewritten. XML ``maxRecords`` / ``startPosition`` override
+        page size and initial offset when valid.
         """
         start_position = 1
+        effective_chunk_size = chunk_size
+        xml_page: tuple[lxml.etree._Element, bool] | None = None
+        if xml_query is not None:
+            xml_root, effective_chunk_size, start_position, xml_as_bytes = self._prepare_xml_paging(
+                xml_query, chunk_size
+            )
+            xml_page = (xml_root, xml_as_bytes)
+
         records_yielded = 0
 
         while True:
-            iso_ok = self._fetch_iso_batch(chunk_size, start_position, cql_query, fes_constraints)
-            if not iso_ok:
+            page = self._fetch_and_parse_page(
+                effective_chunk_size,
+                start_position,
+                cql_query,
+                fes_constraints,
+                xml_page,
+            )
+            if page is None:
                 break
 
-            results, errors_without_id, count = self._parse_iso_batch()
-
-            if not results:
-                break
-
-            if errors_without_id:
-                dc_ids = self._fetch_dc_ids(chunk_size, start_position, cql_query, fes_constraints)
-                self._apply_dc_fallback(results, errors_without_id, dc_ids)
-
+            results, count = page
             yield from results
             records_yielded += count
 
             if max_records is not None and records_yielded >= max_records:
                 break
 
-            next_start = self._next_start_position(start_position, records_in_batch=len(results))
+            next_start = self._advance_start_position(start_position, records_in_batch=len(results))
             if next_start is None:
-                break
-            if next_start <= start_position:
-                logger.warning(
-                    "CSW pagination did not advance (startPosition=%s, next=%s); stopping.",
-                    start_position,
-                    next_start,
-                )
                 break
             start_position = next_start
 
-            if self._all_records_fetched(start_position):
-                break
+    def _fetch_and_parse_page(
+        self,
+        batch_size: int,
+        start_position: int,
+        cql_query: str | None,
+        fes_constraints: list[OgcExpression] | None,
+        xml_page: tuple[lxml.etree._Element, bool] | None,
+    ) -> tuple[list[InspireRecord | RecordProcessingError], int] | None:
+        """Fetch one CSW page and parse it; return None when the page is empty or fetch fails."""
+        if xml_page is not None:
+            xml_root, xml_as_bytes = xml_page
+            iso_ok = self._fetch_iso_batch_xml(xml_root, batch_size, start_position, xml_as_bytes)
+        else:
+            iso_ok = self._fetch_iso_batch(batch_size, start_position, cql_query, fes_constraints)
+        if not iso_ok:
+            return None
+
+        results, errors_without_id, count = self._parse_iso_batch()
+        if not results:
+            return None
+
+        if errors_without_id:
+            if xml_page is not None:
+                xml_root, xml_as_bytes = xml_page
+                dc_ids = self._fetch_dc_ids_xml(xml_root, batch_size, start_position, xml_as_bytes)
+            else:
+                dc_ids = self._fetch_dc_ids(batch_size, start_position, cql_query, fes_constraints)
+            self._apply_dc_fallback(results, errors_without_id, dc_ids)
+
+        return results, count
+
+    def _advance_start_position(self, start_position: int, records_in_batch: int) -> int | None:
+        """Return the next page start, or None when pagination is complete or stuck."""
+        next_start = self._next_start_position(start_position, records_in_batch=records_in_batch)
+        if next_start is None:
+            return None
+        if next_start <= start_position:
+            logger.warning(
+                "CSW pagination did not advance (startPosition=%s, next=%s); stopping.",
+                start_position,
+                next_start,
+            )
+            return None
+        if self._all_records_fetched(next_start):
+            return None
+        return next_start
+
+    def _prepare_xml_paging(
+        self, xml_query: str | bytes, chunk_size: int
+    ) -> tuple[lxml.etree._Element, int, int, bool]:
+        """Parse GetRecords XML and resolve page size / initial start overrides.
+
+        Returns:
+            (root element, page_size, start_position, serialize_as_bytes)
+        """
+        normalized = self._normalize_xml_query(xml_query)
+        as_bytes = isinstance(normalized, (bytes, bytearray))
+        try:
+            root = lxml.etree.fromstring(normalized)
+        except lxml.etree.XMLSyntaxError as exc:
+            raise ValueError(f"xml_query is not well-formed XML: {exc}") from exc
+
+        get_records = self._find_get_records_element(root)
+        if get_records is None:
+            raise ValueError("xml_query must have a CSW GetRecords root element")
+
+        page_size = chunk_size
+        raw_max = get_records.get("maxRecords")
+        if raw_max is not None:
+            xml_max = self._coerce_result_int(raw_max)
+            if xml_max is not None and xml_max > 0:
+                page_size = xml_max
+                logger.info("xml_query maxRecords=%s overrides chunk_size for page size", xml_max)
+            else:
+                logger.warning(
+                    "xml_query maxRecords=%r is invalid or non-positive; using chunk_size=%s",
+                    raw_max,
+                    chunk_size,
+                )
+
+        start_position = 1
+        raw_start = get_records.get("startPosition")
+        if raw_start is not None:
+            xml_start = self._coerce_result_int(raw_start)
+            if xml_start is not None and xml_start >= 1:
+                start_position = xml_start
+                if xml_start != 1:
+                    logger.info("xml_query startPosition=%s overrides initial paging offset", xml_start)
+            else:
+                logger.warning(
+                    "xml_query startPosition=%r is invalid or non-positive; using startPosition=1",
+                    raw_start,
+                )
+
+        return get_records, page_size, start_position, as_bytes
+
+    @staticmethod
+    def _find_get_records_element(root: lxml.etree._Element) -> lxml.etree._Element | None:
+        """Return the GetRecords element from a parsed xml_query document."""
+        if root.tag in _CSW_GET_RECORDS_TAGS:
+            return root
+        local = lxml.etree.QName(root).localname if isinstance(root.tag, str) else ""
+        if local == "GetRecords":
+            return root
+        found = root.find(f".//{{{_CSW_NS}}}GetRecords")
+        return found
+
+    @staticmethod
+    def _serialize_xml_query(root: lxml.etree._Element, as_bytes: bool) -> str | bytes:
+        """Serialize a GetRecords element for OWSLib."""
+        if as_bytes:
+            payload = lxml.etree.tostring(root, encoding="UTF-8", xml_declaration=True)
+            if not isinstance(payload, (bytes, bytearray)):
+                raise TypeError("expected bytes from lxml.etree.tostring")
+            return bytes(payload)
+        payload = lxml.etree.tostring(root, encoding="unicode")
+        if not isinstance(payload, str):
+            raise TypeError("expected str from lxml.etree.tostring")
+        return payload
+
+    def _apply_xml_paging_attrs(self, root: lxml.etree._Element, batch_size: int, start_position: int) -> None:
+        """Set CSW paging attributes on a GetRecords root (in-place)."""
+        root.set("startPosition", str(start_position))
+        root.set("maxRecords", str(batch_size))
+
+    def _fetch_iso_batch_xml(
+        self,
+        xml_root: lxml.etree._Element,
+        batch_size: int,
+        start_position: int,
+        as_bytes: bool,
+        swallow_errors: bool = True,
+    ) -> bool:
+        """Fetch one ISO page by rewriting paging attributes on the xml_query template."""
+        if self._csw is None:
+            self.connect()
+        if self._csw is None:
+            raise RuntimeError("CSW client is not initialized.")
+
+        self._apply_xml_paging_attrs(xml_root, batch_size, start_position)
+        # Keep ISO output when the operator omitted or set a different schema.
+        if not xml_root.get("outputSchema"):
+            xml_root.set("outputSchema", _ISO_OUTPUT_SCHEMA)
+
+        try:
+            self._csw.getrecords2(xml=self._serialize_xml_query(xml_root, as_bytes))
+            return True
+        except (OSError, TimeoutError, ValueError) as e:
+            if swallow_errors:
+                logger.error("Failed to fetch ISO records from CSW at position %d: %s", start_position, e)
+                raise CswConnectionError(f"Failed to fetch ISO records from CSW: {e}") from e
+            raise
+
+    def _fetch_dc_ids_xml(
+        self,
+        xml_root: lxml.etree._Element,
+        batch_size: int,
+        start_position: int,
+        as_bytes: bool,
+    ) -> list[str]:
+        """Fetch DC identifiers for a page using a mutated copy of the xml_query template."""
+        if self._csw is None:
+            self.connect()
+        if self._csw is None:
+            raise RuntimeError("CSW client is not initialized.")
+
+        try:
+            dc_root = copy.deepcopy(xml_root)
+            self._apply_xml_paging_attrs(dc_root, batch_size, start_position)
+            dc_root.set("outputSchema", _DC_OUTPUT_SCHEMA)
+            for element_set in dc_root.iter():
+                if isinstance(element_set.tag, str) and lxml.etree.QName(element_set).localname == "ElementSetName":
+                    element_set.text = "brief"
+                    break
+            self._csw.getrecords2(xml=self._serialize_xml_query(dc_root, as_bytes))
+            return [rec.identifier for rec in self._csw.records.values()]
+        except (OSError, TimeoutError, ValueError) as e:
+            logger.warning("Failed to fetch DC IDs for XML batch at %d: %s", start_position, e)
+            return []
 
     def _next_start_position(self, current_start: int, records_in_batch: int | None = None) -> int | None:
         """Return the next 1-based CSW startPosition, or None when pagination is complete.

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -518,6 +518,15 @@ class CSWClient:
                     raw_start,
                 )
 
+        # Inspect only — request copies apply ISO schema so the shared template stays intact.
+        raw_schema = get_records.get("outputSchema")
+        if raw_schema is not None and raw_schema != _ISO_OUTPUT_SCHEMA:
+            logger.warning(
+                "xml_query outputSchema=%r will be overridden to ISO (%s) for harvest parsing",
+                raw_schema,
+                _ISO_OUTPUT_SCHEMA,
+            )
+
         return get_records, page_size, start_position, as_bytes
 
     @staticmethod
@@ -557,26 +566,24 @@ class CSWClient:
         as_bytes: bool,
         swallow_errors: bool = True,
     ) -> bool:
-        """Fetch one ISO page by rewriting paging attributes on the xml_query template."""
+        """Fetch one ISO page without mutating the shared xml_query template.
+
+        Paging attributes and ISO ``outputSchema`` are applied on a deep copy so the
+        operator template (filter body and original attributes) stays intact across pages.
+        """
         if self._csw is None:
             self.connect()
         if self._csw is None:
             raise RuntimeError("CSW client is not initialized.")
 
-        self._apply_xml_paging_attrs(xml_root, batch_size, start_position)
+        request_root = copy.deepcopy(xml_root)
+        self._apply_xml_paging_attrs(request_root, batch_size, start_position)
         # Same as _fetch_iso_batch: ISO parsing only yields MD_Metadata for gmd schema.
-        current_schema = xml_root.get("outputSchema")
-        if current_schema != _ISO_OUTPUT_SCHEMA:
-            if current_schema is not None:
-                logger.warning(
-                    "xml_query outputSchema=%r overridden to ISO (%s) for harvest parsing",
-                    current_schema,
-                    _ISO_OUTPUT_SCHEMA,
-                )
-            xml_root.set("outputSchema", _ISO_OUTPUT_SCHEMA)
+        if request_root.get("outputSchema") != _ISO_OUTPUT_SCHEMA:
+            request_root.set("outputSchema", _ISO_OUTPUT_SCHEMA)
 
         try:
-            self._csw.getrecords2(xml=self._serialize_xml_query(xml_root, as_bytes))
+            self._csw.getrecords2(xml=self._serialize_xml_query(request_root, as_bytes))
             return True
         except (OSError, TimeoutError, ValueError) as e:
             if swallow_errors:

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -413,7 +413,8 @@ class CSWClient:
             return results, count
         remaining = max_records - records_yielded
         if remaining <= 0:
-            return [], 0
+            # Success budget already exhausted — still surface parse errors from this page.
+            return [item for item in results if isinstance(item, RecordProcessingError)], 0
         if count <= remaining:
             return results, count
 
@@ -575,8 +576,8 @@ class CSWClient:
 
         Paging attributes and ISO ``outputSchema`` are applied on a deep copy so the
         operator template (filter body and original attributes) stays intact across pages.
-        Transient fetch failures are logged and return False so pagination can stop without
-        aborting the generator.
+        Transient ``OSError``/``TimeoutError`` are wrapped as ``CswConnectionError`` so the
+        async retry layer can retry. ``ValueError`` propagates unwrapped (not retryable).
         """
         if self._csw is None:
             self.connect()
@@ -592,9 +593,12 @@ class CSWClient:
         try:
             self._csw.getrecords2(xml=self._serialize_xml_query(request_root, as_bytes))
             return True
-        except (OSError, TimeoutError, ValueError) as e:
+        except ValueError:
+            # Non-retryable (e.g. malformed request); do not wrap as CswConnectionError.
+            raise
+        except (OSError, TimeoutError) as e:
             logger.error("Failed to fetch ISO records from CSW at position %d: %s", start_position, e)
-            return False
+            raise CswConnectionError(f"Failed to fetch ISO records from CSW: {e}") from e
 
     def _fetch_dc_ids_xml(
         self,
@@ -757,8 +761,8 @@ class CSWClient:
     ) -> bool:
         """Fetch a batch of records in ISO 19139 format.
 
-        Transient fetch failures are logged and return False so pagination can stop without
-        aborting the generator.
+        Transient ``OSError``/``TimeoutError`` are wrapped as ``CswConnectionError`` so the
+        async retry layer can retry. ``ValueError`` propagates unwrapped (not retryable).
         """
         if self._csw is None:
             self.connect()
@@ -779,9 +783,12 @@ class CSWClient:
             else:
                 self._csw.getrecords2(**kwargs)
             return True
-        except (OSError, TimeoutError, ValueError) as e:
+        except ValueError:
+            # Non-retryable (e.g. malformed request); do not wrap as CswConnectionError.
+            raise
+        except (OSError, TimeoutError) as e:
             logger.error("Failed to fetch ISO records from CSW at position %d: %s", start_position, e)
-            return False
+            raise CswConnectionError(f"Failed to fetch ISO records from CSW: {e}") from e
 
     def _yield_iso_records(self) -> Iterator[InspireRecord | RecordProcessingError]:
         """Yield parsed ISO records from the last-fetched batch (ISO-first, no DC involved)."""

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -28,7 +28,7 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 _CSW_NS = "http://www.opengis.net/cat/csw/2.0.2"
-_CSW_GET_RECORDS_TAGS = frozenset({"GetRecords", f"{{{_CSW_NS}}}GetRecords"})
+_CSW_GET_RECORDS_TAG = f"{{{_CSW_NS}}}GetRecords"
 _ISO_OUTPUT_SCHEMA = "http://www.isotc211.org/2005/gmd"
 _DC_OUTPUT_SCHEMA = "http://www.opengis.net/cat/csw/2.0.2"
 
@@ -533,10 +533,10 @@ class CSWClient:
     def _find_get_records_element(root: lxml.etree._Element) -> lxml.etree._Element | None:
         """Return *root* when it is a CSW 2.0.2 GetRecords element; otherwise None.
 
-        Only the document root is accepted, and only unnamespaced ``GetRecords`` or the
-        CSW 2.0.2 namespace — not an arbitrary ``*:GetRecords``.
+        Only the document root is accepted, and it must be in the CSW 2.0.2 namespace
+        (not unnamespaced ``GetRecords`` or an arbitrary ``*:GetRecords``).
         """
-        if root.tag in _CSW_GET_RECORDS_TAGS:
+        if root.tag == _CSW_GET_RECORDS_TAG:
             return root
         return None
 

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -532,8 +532,15 @@ class CSWClient:
             raise RuntimeError("CSW client is not initialized.")
 
         self._apply_xml_paging_attrs(xml_root, batch_size, start_position)
-        # Keep ISO output when the operator omitted or set a different schema.
-        if not xml_root.get("outputSchema"):
+        # Same as _fetch_iso_batch: ISO parsing only yields MD_Metadata for gmd schema.
+        current_schema = xml_root.get("outputSchema")
+        if current_schema != _ISO_OUTPUT_SCHEMA:
+            if current_schema is not None:
+                logger.warning(
+                    "xml_query outputSchema=%r overridden to ISO (%s) for harvest parsing",
+                    current_schema,
+                    _ISO_OUTPUT_SCHEMA,
+                )
             xml_root.set("outputSchema", _ISO_OUTPUT_SCHEMA)
 
         try:

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -488,14 +488,16 @@ class CSWClient:
 
     @staticmethod
     def _find_get_records_element(root: lxml.etree._Element) -> lxml.etree._Element | None:
-        """Return the GetRecords element from a parsed xml_query document."""
+        """Return *root* when it is a CSW GetRecords element; otherwise None.
+
+        Only the document root is accepted (no descendant lookup), matching the
+        xml_query contract and keeping namespace declarations on the serialized body.
+        """
         if root.tag in _CSW_GET_RECORDS_TAGS:
             return root
-        local = lxml.etree.QName(root).localname if isinstance(root.tag, str) else ""
-        if local == "GetRecords":
+        if isinstance(root.tag, str) and lxml.etree.QName(root).localname == "GetRecords":
             return root
-        found = root.find(f".//{{{_CSW_NS}}}GetRecords")
-        return found
+        return None
 
     @staticmethod
     def _serialize_xml_query(root: lxml.etree._Element, as_bytes: bool) -> str | bytes:

--- a/middleware/inspire/src/middleware/inspire/csw_client.py
+++ b/middleware/inspire/src/middleware/inspire/csw_client.py
@@ -220,14 +220,16 @@ class CSWClient:
         effective_xml, effective_fes, effective_cql = self._resolve_filter(cql_query, xml_query, fes_constraints)
         effective_chunk_size = chunk_size if chunk_size is not None else self._config.chunk_size
         effective_max_records = max_records if max_records is not None else self._config.max_records
+        # Spec: invalid GetRecords must raise before any network call (including connect).
+        prepared_xml = self._prepare_xml_query_before_network(effective_xml, effective_chunk_size)
 
         if self._csw is None:
             self.connect()
         if self._csw is None:
             raise RuntimeError("CSW client is not initialized.")
 
-        if effective_xml is not None:
-            yield from self._get_records_by_xml(effective_xml, effective_chunk_size, effective_max_records)
+        if prepared_xml is not None:
+            yield from self._get_records_by_xml_prepared(prepared_xml, effective_max_records)
         elif effective_fes is not None:
             yield from self._get_records_by_fes(effective_fes, effective_chunk_size, effective_max_records)
         elif effective_cql is not None:
@@ -247,15 +249,26 @@ class CSWClient:
         effective_xml, effective_fes, effective_cql = self._resolve_filter(cql_query, xml_query, fes_constraints)
         effective_chunk_size = chunk_size if chunk_size is not None else self._config.chunk_size
         effective_max_records = max_records if max_records is not None else self._config.max_records
+        # Spec: invalid GetRecords must raise before any network call (including connect).
+        prepared_xml = self._prepare_xml_query_before_network(effective_xml, effective_chunk_size)
 
         if self._csw is None:
             await self._retry_async(self._connect, "connect")
         if self._csw is None:
             raise RuntimeError("CSW client is not initialized.")
 
-        name, fn, args = self._pick_strategy(
-            effective_xml, effective_fes, effective_cql, effective_chunk_size, effective_max_records
-        )
+        strategy: tuple[str, Callable[..., Iterator[InspireRecord | RecordProcessingError]], tuple[object, ...]]
+        if prepared_xml is not None:
+            strategy = (
+                "get_records_by_xml",
+                self._get_records_by_xml_prepared,
+                (prepared_xml, effective_max_records),
+            )
+        else:
+            strategy = self._pick_strategy(
+                effective_xml, effective_fes, effective_cql, effective_chunk_size, effective_max_records
+            )
+        name, fn, args = strategy
         records = await self._retry_async(self._iter_to_list, name, fn, *args)
         for item in records:
             yield item
@@ -318,12 +331,30 @@ class CSWClient:
             return xml_query.encode("utf-8")
         return xml_query
 
+    def _prepare_xml_query_before_network(
+        self, xml_query: str | bytes | None, chunk_size: int
+    ) -> tuple[lxml.etree._Element, int, int, bool] | None:
+        """Parse/validate ``xml_query`` before connect; return prepared paging state or None."""
+        if xml_query is None:
+            return None
+        return self._prepare_xml_paging(xml_query, chunk_size)
+
     def _get_records_by_xml(
         self, xml_query: str | bytes, chunk_size: int, max_records: int | None
     ) -> Iterator[InspireRecord | RecordProcessingError]:
         """Retrieve records using a GetRecords XML body with pagination."""
         logger.info("Using XML GetRecords request for harvesting (paginated).")
-        yield from self._get_records_paged(chunk_size, None, None, max_records, xml_query=xml_query)
+        yield from self._get_records_paged(chunk_size, None, None, max_records, xml=xml_query)
+
+    def _get_records_by_xml_prepared(
+        self,
+        prepared_xml: tuple[lxml.etree._Element, int, int, bool],
+        max_records: int | None,
+    ) -> Iterator[InspireRecord | RecordProcessingError]:
+        """Paginate using XML already validated/prepared before connect."""
+        logger.info("Using XML GetRecords request for harvesting (paginated).")
+        page_size = prepared_xml[1]
+        yield from self._get_records_paged(page_size, None, None, max_records, xml=prepared_xml)
 
     def _get_records_by_fes(
         self, fes_constraints: list[OgcExpression], chunk_size: int, max_records: int | None
@@ -344,7 +375,7 @@ class CSWClient:
         cql_query: str | None,
         fes_constraints: list[OgcExpression] | None,
         max_records: int | None,
-        xml_query: str | bytes | None = None,
+        xml: str | bytes | tuple[lxml.etree._Element, int, int, bool] | None = None,
     ) -> Iterator[InspireRecord | RecordProcessingError]:
         """Retrieve all records using pagination, fetching chunk_size records per request.
 
@@ -352,17 +383,18 @@ class CSWClient:
         servers treat the first page as position 1, then ``start += page_size`` requests
         position ``page_size`` again and duplicates one record per page boundary.
 
-        When ``xml_query`` is set, the GetRecords filter body is preserved and only
-        paging attributes are rewritten. XML ``maxRecords`` / ``startPosition`` override
-        page size and initial offset when valid.
+        When ``xml`` is set, the GetRecords filter body is preserved and only paging
+        attributes are rewritten. Pass prepared paging state from
+        ``_prepare_xml_query_before_network`` so invalid XML fails before ``connect()``.
         """
         start_position = 1
         effective_chunk_size = chunk_size
         xml_page: tuple[lxml.etree._Element, bool] | None = None
-        if xml_query is not None:
-            xml_root, effective_chunk_size, start_position, xml_as_bytes = self._prepare_xml_paging(
-                xml_query, chunk_size
-            )
+        if isinstance(xml, tuple):
+            xml_root, effective_chunk_size, start_position, xml_as_bytes = xml
+            xml_page = (xml_root, xml_as_bytes)
+        elif xml is not None:
+            xml_root, effective_chunk_size, start_position, xml_as_bytes = self._prepare_xml_paging(xml, chunk_size)
             xml_page = (xml_root, xml_as_bytes)
 
         records_yielded = 0
@@ -856,6 +888,8 @@ class CSWClient:
             Total number of matching records.
         """
         effective_xml, effective_fes, effective_cql = self._resolve_filter(cql_query, xml_query, fes_constraints)
+        # Spec: invalid GetRecords must raise before any network call (including connect).
+        self._prepare_xml_query_before_network(effective_xml, self._config.chunk_size)
 
         if self._csw is None:
             self.connect()

--- a/middleware/inspire/tests/unit/test_csw_client.py
+++ b/middleware/inspire/tests/unit/test_csw_client.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from middleware.harvester.errors import RecordProcessingError
 from middleware.inspire.config import Config
 from middleware.inspire.csw_client import CSWClient
 from middleware.inspire.errors import CswConnectionError
@@ -726,6 +727,72 @@ def test_max_records_truncates_oversized_page() -> None:
 
     assert len(results) == 2
     assert call_count == 1
+
+
+def test_limit_page_keeps_errors_after_success_budget() -> None:
+    """max_records caps successes only; RecordProcessingErrors on the page are still kept."""
+    ok1, ok2, ok3 = MagicMock(), MagicMock(), MagicMock()
+    err_mid = RecordProcessingError("mid", record_id="e-mid")
+    err_tail = RecordProcessingError("tail", record_id="e-tail")
+    page: list[MagicMock | RecordProcessingError] = [ok1, err_mid, ok2, ok3, err_tail]
+
+    limited, successes = CSWClient._limit_page_to_max_records(  # noqa: SLF001
+        page,  # type: ignore[arg-type]
+        count=3,
+        records_yielded=0,
+        max_records=2,
+    )
+
+    assert successes == 2
+    assert limited == [ok1, err_mid, ok2, err_tail]
+
+
+def test_pagination_fallback_uses_fetched_size_not_trimmed_yield() -> None:
+    """Missing nextrecord/returned must advance by the fetched page size, not a trimmed yield list."""
+    starts: list[int] = []
+    batch_sizes_seen: list[int] = []
+    client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=5, max_records=100))
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+
+    def fake_fetch(
+        batch_size: int,
+        start_position: int,
+        cql_query: str | None,
+        fes_constraints: object,
+    ) -> bool:
+        del batch_size, cql_query, fes_constraints
+        starts.append(start_position)
+        csw.results = {"matches": 20, "returned": None, "nextrecord": None}
+        return True
+
+    def fake_limit(
+        results: list[object],
+        count: int,
+        records_yielded: int,
+        max_records: int | None,
+    ) -> tuple[list[object], int]:
+        del count, records_yielded, max_records
+        # Shrink the yield list while leaving budget so pagination continues.
+        return results[:2], 2
+
+    real_advance = client._advance_start_position  # noqa: SLF001
+
+    def tracking_advance(start_position: int, records_in_batch: int) -> int | None:
+        batch_sizes_seen.append(records_in_batch)
+        return real_advance(start_position, records_in_batch=records_in_batch)
+
+    with (
+        patch.object(CSWClient, "_fetch_iso_batch", side_effect=fake_fetch),
+        patch.object(CSWClient, "_parse_iso_batch", return_value=([object()] * 5, [], 5)),
+        patch.object(CSWClient, "_limit_page_to_max_records", side_effect=fake_limit),
+        patch.object(client, "_advance_start_position", side_effect=tracking_advance),
+    ):
+        list(client._get_records_paged(5, None, None, 100))  # noqa: SLF001
+
+    assert batch_sizes_seen[0] == 5
+    assert starts[0] == 1
+    assert starts[1] == 6
 
 
 def test_xml_iso_fetch_does_not_mutate_shared_template() -> None:

--- a/middleware/inspire/tests/unit/test_csw_client.py
+++ b/middleware/inspire/tests/unit/test_csw_client.py
@@ -540,3 +540,124 @@ def test_paged_harvest_stops_when_nextrecord_does_not_advance() -> None:
         list(client._get_records_paged(50, None, None, None))  # noqa: SLF001
 
     assert starts == [1]
+
+
+def _minimal_get_records_xml(**attrs: str) -> str:
+    attr_str = " ".join(f'{key}="{value}"' for key, value in attrs.items())
+    return (
+        '<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" '
+        'service="CSW" version="2.0.2" resultType="results" '
+        'outputSchema="http://www.isotc211.org/2005/gmd"'
+        f"{(' ' + attr_str) if attr_str else ''}>"
+        '<csw:Query typeNames="csw:Record">'
+        "<csw:ElementSetName>full</csw:ElementSetName>"
+        "</csw:Query>"
+        "</csw:GetRecords>"
+    )
+
+
+def test_xml_paging_uses_chunk_size_across_pages() -> None:
+    """xml_query without maxRecords uses config chunk_size and pages via nextrecord."""
+    client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=2))
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    sent: list[str] = []
+    pages = [
+        {"matches": 3, "returned": 2, "nextrecord": 3},
+        {"matches": 3, "returned": 1, "nextrecord": 0},
+    ]
+
+    def fake_getrecords2(*, xml: str) -> None:
+        sent.append(xml)
+        page = pages[len(sent) - 1]
+        csw.results = page
+        csw.records = {}
+
+    csw.getrecords2.side_effect = fake_getrecords2
+
+    with patch.object(CSWClient, "_parse_iso_batch", side_effect=[([object(), object()], [], 2), ([object()], [], 1)]):
+        list(client.get_records(xml_query=_minimal_get_records_xml()))
+
+    assert len(sent) == 2
+    assert 'maxRecords="2"' in sent[0]
+    assert 'startPosition="1"' in sent[0]
+    assert 'maxRecords="2"' in sent[1]
+    assert 'startPosition="3"' in sent[1]
+
+
+def test_xml_max_records_overrides_chunk_size() -> None:
+    """Valid XML maxRecords overrides config chunk_size as page size only."""
+    client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=50))
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    csw.results = {"matches": 1, "returned": 1, "nextrecord": 0}
+    csw.records = {}
+
+    with patch.object(CSWClient, "_parse_iso_batch", return_value=([object()], [], 1)):
+        list(client.get_records(xml_query=_minimal_get_records_xml(maxRecords="7")))
+
+    sent_xml = csw.getrecords2.call_args.kwargs["xml"]
+    assert 'maxRecords="7"' in sent_xml
+
+
+def test_xml_start_position_overrides_initial_offset() -> None:
+    """Valid XML startPosition is used as the first page offset."""
+    client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=10))
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    csw.results = {"matches": 20, "returned": 1, "nextrecord": 0}
+    csw.records = {}
+
+    with patch.object(CSWClient, "_parse_iso_batch", return_value=([object()], [], 1)):
+        list(client.get_records(xml_query=_minimal_get_records_xml(startPosition="11")))
+
+    sent_xml = csw.getrecords2.call_args.kwargs["xml"]
+    assert 'startPosition="11"' in sent_xml
+
+
+def test_xml_config_max_records_caps_harvest() -> None:
+    """Config max_records stops XML harvest across pages (not XML maxRecords)."""
+    client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=2, max_records=2))
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    call_count = 0
+
+    def fake_getrecords2(*, xml: str) -> None:
+        del xml
+        nonlocal call_count
+        call_count += 1
+        csw.results = {"matches": 100, "returned": 2, "nextrecord": 3}
+        csw.records = {}
+
+    csw.getrecords2.side_effect = fake_getrecords2
+
+    with patch.object(CSWClient, "_parse_iso_batch", return_value=([object(), object()], [], 2)):
+        results = list(client.get_records(xml_query=_minimal_get_records_xml()))
+
+    assert len(results) == 2
+    assert call_count == 1
+
+
+def test_xml_invalid_paging_attrs_log_and_fall_back(caplog: pytest.LogCaptureFixture) -> None:
+    """Invalid XML maxRecords/startPosition are ignored with a warning."""
+    client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=9))
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    csw.results = {"matches": 1, "returned": 1, "nextrecord": 0}
+    csw.records = {}
+
+    with (
+        caplog.at_level(logging.WARNING, logger="middleware.inspire.csw_client"),
+        patch.object(CSWClient, "_parse_iso_batch", return_value=([object()], [], 1)),
+    ):
+        list(
+            client.get_records(
+                xml_query=_minimal_get_records_xml(maxRecords="0", startPosition="bogus"),
+            )
+        )
+
+    sent_xml = csw.getrecords2.call_args.kwargs["xml"]
+    assert 'maxRecords="9"' in sent_xml
+    assert 'startPosition="1"' in sent_xml
+    assert any("maxRecords" in record.message for record in caplog.records)
+    assert any("startPosition" in record.message for record in caplog.records)

--- a/middleware/inspire/tests/unit/test_csw_client.py
+++ b/middleware/inspire/tests/unit/test_csw_client.py
@@ -410,9 +410,8 @@ def test_paged_harvest_advances_when_nextrecord_and_returned_missing() -> None:
         start_position: int,
         cql_query: str | None,
         fes_constraints: object,
-        swallow_errors: bool = True,
     ) -> bool:
-        del batch_size, cql_query, fes_constraints, swallow_errors
+        del batch_size, cql_query, fes_constraints
         starts.append(start_position)
         csw.results = {"matches": 113, "returned": None, "nextrecord": None}
         return True
@@ -446,9 +445,8 @@ def test_paged_harvest_starts_at_one_and_advances_without_overlap() -> None:
         start_position: int,
         cql_query: str | None,
         fes_constraints: object,
-        swallow_errors: bool = True,
     ) -> bool:
-        del batch_size, cql_query, fes_constraints, swallow_errors
+        del batch_size, cql_query, fes_constraints
         page_index = len(starts)
         starts.append(start_position)
         csw.results = {
@@ -493,9 +491,8 @@ def test_paged_harvest_fetches_final_record_when_nextrecord_equals_matches() -> 
         start_position: int,
         cql_query: str | None,
         fes_constraints: object,
-        swallow_errors: bool = True,
     ) -> bool:
-        del batch_size, cql_query, fes_constraints, swallow_errors
+        del batch_size, cql_query, fes_constraints
         page_index = len(starts)
         starts.append(start_position)
         csw.results = {
@@ -526,9 +523,8 @@ def test_paged_harvest_stops_when_nextrecord_does_not_advance() -> None:
         start_position: int,
         cql_query: str | None,
         fes_constraints: object,
-        swallow_errors: bool = True,
     ) -> bool:
-        del batch_size, cql_query, fes_constraints, swallow_errors
+        del batch_size, cql_query, fes_constraints
         starts.append(start_position)
         csw.results = {"matches": 200, "returned": 50, "nextrecord": start_position}
         return True
@@ -791,3 +787,55 @@ def test_xml_non_iso_output_schema_overridden(caplog: pytest.LogCaptureFixture) 
     sent_xml = csw.getrecords2.call_args.kwargs["xml"]
     assert 'outputSchema="http://www.isotc211.org/2005/gmd"' in sent_xml
     assert any("outputSchema" in record.message for record in caplog.records)
+
+
+def test_fetch_iso_batch_returns_false_on_error() -> None:
+    """ISO fetch failures are logged and return False instead of raising."""
+    client = CSWClient(_make_csw_config())
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    csw.getrecords2.side_effect = TimeoutError("timed out")
+
+    assert client._fetch_iso_batch(10, 1, None, None) is False  # noqa: SLF001
+
+
+def test_paged_harvest_stops_gracefully_on_iso_fetch_failure() -> None:
+    """A mid-harvest ISO fetch failure ends pagination without raising."""
+    client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=2))
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    call_count = 0
+
+    def fake_getrecords2(**_kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            csw.results = {"matches": 100, "returned": 2, "nextrecord": 3}
+            csw.records = {}
+            return
+        raise TimeoutError("page 2 failed")
+
+    csw.getrecords2.side_effect = fake_getrecords2
+
+    with patch.object(CSWClient, "_parse_iso_batch", return_value=([object(), object()], [], 2)):
+        results = list(client.get_records())
+
+    assert len(results) == 2
+    assert call_count == 2
+
+
+def test_fetch_iso_batch_xml_returns_false_on_error() -> None:
+    """XML ISO fetch failures return False on network error."""
+    client = CSWClient(_make_csw_config())
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    csw.getrecords2.side_effect = OSError("boom")
+    root, _page_size, _start, as_bytes = client._prepare_xml_paging(  # noqa: SLF001
+        _minimal_get_records_xml(),
+        chunk_size=10,
+    )
+
+    assert (
+        client._fetch_iso_batch_xml(root, batch_size=10, start_position=1, as_bytes=as_bytes)  # noqa: SLF001
+        is False
+    )

--- a/middleware/inspire/tests/unit/test_csw_client.py
+++ b/middleware/inspire/tests/unit/test_csw_client.py
@@ -661,3 +661,27 @@ def test_xml_invalid_paging_attrs_log_and_fall_back(caplog: pytest.LogCaptureFix
     assert 'startPosition="1"' in sent_xml
     assert any("maxRecords" in record.message for record in caplog.records)
     assert any("startPosition" in record.message for record in caplog.records)
+
+
+def test_xml_query_requires_get_records_root() -> None:
+    """xml_query without a GetRecords root raises before contacting CSW."""
+    client = CSWClient(_make_csw_config())
+    object.__setattr__(client, "_csw", MagicMock())
+
+    with pytest.raises(ValueError, match="GetRecords"):
+        list(client.get_records(xml_query="<Filter/>"))
+
+
+def test_xml_query_rejects_nested_get_records() -> None:
+    """GetRecords must be the document root, not a descendant."""
+    client = CSWClient(_make_csw_config())
+    object.__setattr__(client, "_csw", MagicMock())
+    wrapped = (
+        "<wrapper>"
+        '<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" '
+        'service="CSW" version="2.0.2"/>'
+        "</wrapper>"
+    )
+
+    with pytest.raises(ValueError, match="GetRecords"):
+        list(client.get_records(xml_query=wrapped))

--- a/middleware/inspire/tests/unit/test_csw_client.py
+++ b/middleware/inspire/tests/unit/test_csw_client.py
@@ -687,6 +687,42 @@ def test_xml_query_rejects_nested_get_records() -> None:
         list(client.get_records(xml_query=wrapped))
 
 
+def test_xml_query_rejects_wrong_get_records_namespace() -> None:
+    """GetRecords in a non-CSW namespace is rejected."""
+    client = CSWClient(_make_csw_config())
+    object.__setattr__(client, "_csw", MagicMock())
+
+    with pytest.raises(ValueError, match="GetRecords"):
+        list(client.get_records(xml_query='<GetRecords xmlns="http://example.org/not-csw"/>'))
+
+
+def test_max_records_truncates_oversized_page() -> None:
+    """max_records must not yield more successful records than N within a page."""
+    client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=10, max_records=2))
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    csw.results = {"matches": 10, "returned": 5, "nextrecord": 6}
+    csw.records = {}
+    call_count = 0
+
+    def fake_getrecords2(**_kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+
+    csw.getrecords2.side_effect = fake_getrecords2
+    page: tuple[list[object], list[object], int] = (
+        [object(), object(), object(), object(), object()],
+        [],
+        5,
+    )
+
+    with patch.object(CSWClient, "_parse_iso_batch", return_value=page):
+        results = list(client.get_records(xml_query=_minimal_get_records_xml()))
+
+    assert len(results) == 2
+    assert call_count == 1
+
+
 def test_xml_non_iso_output_schema_overridden(caplog: pytest.LogCaptureFixture) -> None:
     """ISO fetch path forces gmd outputSchema even when xml_query sets another schema."""
     client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=5))

--- a/middleware/inspire/tests/unit/test_csw_client.py
+++ b/middleware/inspire/tests/unit/test_csw_client.py
@@ -696,6 +696,15 @@ def test_xml_query_rejects_wrong_get_records_namespace() -> None:
         list(client.get_records(xml_query='<GetRecords xmlns="http://example.org/not-csw"/>'))
 
 
+def test_xml_query_rejects_unnamespaced_get_records() -> None:
+    """Bare GetRecords without the CSW 2.0.2 namespace is rejected."""
+    client = CSWClient(_make_csw_config())
+    object.__setattr__(client, "_csw", MagicMock())
+
+    with pytest.raises(ValueError, match="GetRecords"):
+        list(client.get_records(xml_query='<GetRecords service="CSW" version="2.0.2"/>'))
+
+
 def test_max_records_truncates_oversized_page() -> None:
     """max_records must not yield more successful records than N within a page."""
     client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=10, max_records=2))

--- a/middleware/inspire/tests/unit/test_csw_client.py
+++ b/middleware/inspire/tests/unit/test_csw_client.py
@@ -685,3 +685,31 @@ def test_xml_query_rejects_nested_get_records() -> None:
 
     with pytest.raises(ValueError, match="GetRecords"):
         list(client.get_records(xml_query=wrapped))
+
+
+def test_xml_non_iso_output_schema_overridden(caplog: pytest.LogCaptureFixture) -> None:
+    """ISO fetch path forces gmd outputSchema even when xml_query sets another schema."""
+    client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=5))
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    csw.results = {"matches": 1, "returned": 1, "nextrecord": 0}
+    csw.records = {}
+    xml_query = (
+        '<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" '
+        'service="CSW" version="2.0.2" resultType="results" '
+        'outputSchema="http://www.opengis.net/cat/csw/2.0.2">'
+        '<csw:Query typeNames="csw:Record">'
+        "<csw:ElementSetName>full</csw:ElementSetName>"
+        "</csw:Query>"
+        "</csw:GetRecords>"
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger="middleware.inspire.csw_client"),
+        patch.object(CSWClient, "_parse_iso_batch", return_value=([object()], [], 1)),
+    ):
+        list(client.get_records(xml_query=xml_query))
+
+    sent_xml = csw.getrecords2.call_args.kwargs["xml"]
+    assert 'outputSchema="http://www.isotc211.org/2005/gmd"' in sent_xml
+    assert any("outputSchema" in record.message for record in caplog.records)

--- a/middleware/inspire/tests/unit/test_csw_client.py
+++ b/middleware/inspire/tests/unit/test_csw_client.py
@@ -87,7 +87,7 @@ def test_get_record_count_uses_xml_query() -> None:
     object.__setattr__(client, "_csw", fake_csw)
 
     expected_count = 7
-    count = client.get_record_count(xml_query="<xml />")
+    count = client.get_record_count(xml_query=_minimal_get_records_xml())
 
     assert count == expected_count
 
@@ -105,7 +105,7 @@ def test_get_record_count_uses_xml_query_with_encoding_declaration() -> None:
     object.__setattr__(client, "_csw", fake_csw)
 
     expected_count = 11
-    xml_request = '<?xml version="1.0" encoding="UTF-8"?><xml />'
+    xml_request = '<?xml version="1.0" encoding="UTF-8"?>' + _minimal_get_records_xml()
     count = client.get_record_count(xml_query=xml_request)
 
     assert count == expected_count
@@ -330,9 +330,9 @@ async def test_get_records_async_uses_run_in_executor_for_xml_path() -> None:
         patch("middleware.inspire.csw_client.asyncio.get_running_loop", return_value=fake_loop),
         patch.object(CSWClient, "_get_executor", return_value=MagicMock()),
         patch.object(CSWClient, "_connect", return_value=None),
-        patch.object(CSWClient, "_get_records_by_xml", return_value=iter(["record1"])) as mock_sync,
+        patch.object(CSWClient, "_get_records_by_xml_prepared", return_value=iter(["record1"])) as mock_sync,
     ):
-        records = [item async for item in client.get_records_async(xml_query="<xml/>")]
+        records = [item async for item in client.get_records_async(xml_query=_minimal_get_records_xml())]
 
     assert records == ["record1"]
     assert mock_sync.called
@@ -664,16 +664,19 @@ def test_xml_invalid_paging_attrs_log_and_fall_back(caplog: pytest.LogCaptureFix
 def test_xml_query_requires_get_records_root() -> None:
     """xml_query without a GetRecords root raises before contacting CSW."""
     client = CSWClient(_make_csw_config())
-    object.__setattr__(client, "_csw", MagicMock())
 
-    with pytest.raises(ValueError, match="GetRecords"):
+    with (
+        patch.object(client, "connect") as mock_connect,
+        pytest.raises(ValueError, match="GetRecords"),
+    ):
         list(client.get_records(xml_query="<Filter/>"))
+
+    mock_connect.assert_not_called()
 
 
 def test_xml_query_rejects_nested_get_records() -> None:
     """GetRecords must be the document root, not a descendant."""
     client = CSWClient(_make_csw_config())
-    object.__setattr__(client, "_csw", MagicMock())
     wrapped = (
         "<wrapper>"
         '<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" '
@@ -681,26 +684,39 @@ def test_xml_query_rejects_nested_get_records() -> None:
         "</wrapper>"
     )
 
-    with pytest.raises(ValueError, match="GetRecords"):
+    with (
+        patch.object(client, "connect") as mock_connect,
+        pytest.raises(ValueError, match="GetRecords"),
+    ):
         list(client.get_records(xml_query=wrapped))
+
+    mock_connect.assert_not_called()
 
 
 def test_xml_query_rejects_wrong_get_records_namespace() -> None:
     """GetRecords in a non-CSW namespace is rejected."""
     client = CSWClient(_make_csw_config())
-    object.__setattr__(client, "_csw", MagicMock())
 
-    with pytest.raises(ValueError, match="GetRecords"):
+    with (
+        patch.object(client, "connect") as mock_connect,
+        pytest.raises(ValueError, match="GetRecords"),
+    ):
         list(client.get_records(xml_query='<GetRecords xmlns="http://example.org/not-csw"/>'))
+
+    mock_connect.assert_not_called()
 
 
 def test_xml_query_rejects_unnamespaced_get_records() -> None:
     """Bare GetRecords without the CSW 2.0.2 namespace is rejected."""
     client = CSWClient(_make_csw_config())
-    object.__setattr__(client, "_csw", MagicMock())
 
-    with pytest.raises(ValueError, match="GetRecords"):
+    with (
+        patch.object(client, "connect") as mock_connect,
+        pytest.raises(ValueError, match="GetRecords"),
+    ):
         list(client.get_records(xml_query='<GetRecords service="CSW" version="2.0.2"/>'))
+
+    mock_connect.assert_not_called()
 
 
 def test_max_records_truncates_oversized_page() -> None:

--- a/middleware/inspire/tests/unit/test_csw_client.py
+++ b/middleware/inspire/tests/unit/test_csw_client.py
@@ -723,6 +723,39 @@ def test_max_records_truncates_oversized_page() -> None:
     assert call_count == 1
 
 
+def test_xml_iso_fetch_does_not_mutate_shared_template() -> None:
+    """ISO page fetches must not rewrite the shared xml_query root in-place."""
+    client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=2))
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    csw.results = {"matches": 3, "returned": 2, "nextrecord": 3}
+    csw.records = {}
+
+    original_schema = "http://www.opengis.net/cat/csw/2.0.2"
+    xml_query = (
+        '<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" '
+        'service="CSW" version="2.0.2" resultType="results" '
+        f'outputSchema="{original_schema}" startPosition="9" maxRecords="99">'
+        '<csw:Query typeNames="csw:Record">'
+        "<csw:ElementSetName>full</csw:ElementSetName>"
+        "</csw:Query>"
+        "</csw:GetRecords>"
+    )
+    root, page_size, start, as_bytes = client._prepare_xml_paging(xml_query, chunk_size=2)  # noqa: SLF001
+    assert page_size == 99
+    assert start == 9
+
+    client._fetch_iso_batch_xml(root, batch_size=2, start_position=1, as_bytes=as_bytes)  # noqa: SLF001
+    client._fetch_iso_batch_xml(root, batch_size=2, start_position=3, as_bytes=as_bytes)  # noqa: SLF001
+
+    assert root.get("outputSchema") == original_schema
+    assert root.get("startPosition") == "9"
+    assert root.get("maxRecords") == "99"
+    sent = csw.getrecords2.call_args_list[-1].kwargs["xml"]
+    assert 'outputSchema="http://www.isotc211.org/2005/gmd"' in sent
+    assert 'startPosition="3"' in sent
+
+
 def test_xml_non_iso_output_schema_overridden(caplog: pytest.LogCaptureFixture) -> None:
     """ISO fetch path forces gmd outputSchema even when xml_query sets another schema."""
     client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=5))

--- a/middleware/inspire/tests/unit/test_csw_client.py
+++ b/middleware/inspire/tests/unit/test_csw_client.py
@@ -747,6 +747,23 @@ def test_limit_page_keeps_errors_after_success_budget() -> None:
     assert limited == [ok1, err_mid, ok2, err_tail]
 
 
+def test_limit_page_keeps_errors_when_success_budget_already_exhausted() -> None:
+    """When remaining <= 0, successes are dropped but page errors are still returned."""
+    ok = MagicMock()
+    err = RecordProcessingError("still report me", record_id="e-1")
+    page: list[MagicMock | RecordProcessingError] = [ok, err]
+
+    limited, successes = CSWClient._limit_page_to_max_records(  # noqa: SLF001
+        page,  # type: ignore[arg-type]
+        count=1,
+        records_yielded=5,
+        max_records=5,
+    )
+
+    assert successes == 0
+    assert limited == [err]
+
+
 def test_pagination_fallback_uses_fetched_size_not_trimmed_yield() -> None:
     """Missing nextrecord/returned must advance by the fetched page size, not a trimmed yield list."""
     starts: list[int] = []
@@ -856,18 +873,30 @@ def test_xml_non_iso_output_schema_overridden(caplog: pytest.LogCaptureFixture) 
     assert any("outputSchema" in record.message for record in caplog.records)
 
 
-def test_fetch_iso_batch_returns_false_on_error() -> None:
-    """ISO fetch failures are logged and return False instead of raising."""
+def test_fetch_iso_batch_raises_csw_connection_error_on_failure() -> None:
+    """ISO fetch failures raise CswConnectionError so async retry can observe them."""
     client = CSWClient(_make_csw_config())
     csw = MagicMock()
     object.__setattr__(client, "_csw", csw)
     csw.getrecords2.side_effect = TimeoutError("timed out")
 
-    assert client._fetch_iso_batch(10, 1, None, None) is False  # noqa: SLF001
+    with pytest.raises(CswConnectionError, match="Failed to fetch ISO records"):
+        client._fetch_iso_batch(10, 1, None, None)  # noqa: SLF001
 
 
-def test_paged_harvest_stops_gracefully_on_iso_fetch_failure() -> None:
-    """A mid-harvest ISO fetch failure ends pagination without raising."""
+def test_fetch_iso_batch_propagates_value_error() -> None:
+    """ValueError from OWSLib must propagate unwrapped (not retryable)."""
+    client = CSWClient(_make_csw_config())
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    csw.getrecords2.side_effect = ValueError("bad filter")
+
+    with pytest.raises(ValueError, match="bad filter"):
+        client._fetch_iso_batch(10, 1, None, None)  # noqa: SLF001
+
+
+def test_paged_harvest_raises_on_iso_fetch_failure() -> None:
+    """A mid-harvest ISO fetch failure raises CswConnectionError (retryable on async path)."""
     client = CSWClient(Config(csw_url="https://example.com/csw", timeout=5, chunk_size=2))
     csw = MagicMock()
     object.__setattr__(client, "_csw", csw)
@@ -884,15 +913,17 @@ def test_paged_harvest_stops_gracefully_on_iso_fetch_failure() -> None:
 
     csw.getrecords2.side_effect = fake_getrecords2
 
-    with patch.object(CSWClient, "_parse_iso_batch", return_value=([object(), object()], [], 2)):
-        results = list(client.get_records())
+    with (
+        patch.object(CSWClient, "_parse_iso_batch", return_value=([object(), object()], [], 2)),
+        pytest.raises(CswConnectionError, match="Failed to fetch ISO records"),
+    ):
+        list(client.get_records())
 
-    assert len(results) == 2
     assert call_count == 2
 
 
-def test_fetch_iso_batch_xml_returns_false_on_error() -> None:
-    """XML ISO fetch failures return False on network error."""
+def test_fetch_iso_batch_xml_raises_csw_connection_error_on_failure() -> None:
+    """XML ISO fetch failures raise CswConnectionError on network error."""
     client = CSWClient(_make_csw_config())
     csw = MagicMock()
     object.__setattr__(client, "_csw", csw)
@@ -902,7 +933,20 @@ def test_fetch_iso_batch_xml_returns_false_on_error() -> None:
         chunk_size=10,
     )
 
-    assert (
+    with pytest.raises(CswConnectionError, match="Failed to fetch ISO records"):
         client._fetch_iso_batch_xml(root, batch_size=10, start_position=1, as_bytes=as_bytes)  # noqa: SLF001
-        is False
+
+
+def test_fetch_iso_batch_xml_propagates_value_error() -> None:
+    """ValueError from XML ISO fetch must propagate unwrapped (not retryable)."""
+    client = CSWClient(_make_csw_config())
+    csw = MagicMock()
+    object.__setattr__(client, "_csw", csw)
+    csw.getrecords2.side_effect = ValueError("bad xml request")
+    root, _page_size, _start, as_bytes = client._prepare_xml_paging(  # noqa: SLF001
+        _minimal_get_records_xml(),
+        chunk_size=10,
     )
+
+    with pytest.raises(ValueError, match="bad xml request"):
+        client._fetch_iso_batch_xml(root, batch_size=10, start_position=1, as_bytes=as_bytes)  # noqa: SLF001

--- a/middleware/inspire/tests/unit/test_csw_client.py
+++ b/middleware/inspire/tests/unit/test_csw_client.py
@@ -11,6 +11,7 @@ from middleware.harvester.errors import RecordProcessingError
 from middleware.inspire.config import Config
 from middleware.inspire.csw_client import CSWClient
 from middleware.inspire.errors import CswConnectionError
+from middleware.inspire.models import InspireRecord
 
 _expected_record_count = 42
 
@@ -729,15 +730,20 @@ def test_max_records_truncates_oversized_page() -> None:
     assert call_count == 1
 
 
+def _stub_inspire_record(identifier: str) -> InspireRecord:
+    """Minimal InspireRecord for limit/pagination unit tests."""
+    return InspireRecord.model_construct(identifier=identifier, title=identifier, abstract="")
+
+
 def test_limit_page_keeps_errors_after_success_budget() -> None:
     """max_records caps successes only; RecordProcessingErrors on the page are still kept."""
-    ok1, ok2, ok3 = MagicMock(), MagicMock(), MagicMock()
+    ok1, ok2, ok3 = (_stub_inspire_record(f"ok-{i}") for i in range(1, 4))
     err_mid = RecordProcessingError("mid", record_id="e-mid")
     err_tail = RecordProcessingError("tail", record_id="e-tail")
-    page: list[MagicMock | RecordProcessingError] = [ok1, err_mid, ok2, ok3, err_tail]
+    page: list[InspireRecord | RecordProcessingError] = [ok1, err_mid, ok2, ok3, err_tail]
 
     limited, successes = CSWClient._limit_page_to_max_records(  # noqa: SLF001
-        page,  # type: ignore[arg-type]
+        page,
         count=3,
         records_yielded=0,
         max_records=2,
@@ -749,12 +755,12 @@ def test_limit_page_keeps_errors_after_success_budget() -> None:
 
 def test_limit_page_keeps_errors_when_success_budget_already_exhausted() -> None:
     """When remaining <= 0, successes are dropped but page errors are still returned."""
-    ok = MagicMock()
+    ok = _stub_inspire_record("ok-1")
     err = RecordProcessingError("still report me", record_id="e-1")
-    page: list[MagicMock | RecordProcessingError] = [ok, err]
+    page: list[InspireRecord | RecordProcessingError] = [ok, err]
 
     limited, successes = CSWClient._limit_page_to_max_records(  # noqa: SLF001
-        page,  # type: ignore[arg-type]
+        page,
         count=1,
         records_yielded=5,
         max_records=5,

--- a/middleware/inspire/tests/unit/test_harvester.py
+++ b/middleware/inspire/tests/unit/test_harvester.py
@@ -97,13 +97,24 @@ def test_get_records_xml(mock_csw_cls: MagicMock) -> None:
     mock_record.dataquality = mock_dataquality
 
     mock_csw_instance.records = {"uuid-xml": mock_record}
+    mock_csw_instance.results = {"matches": 1, "returned": 1, "nextrecord": 0}
 
-    client = CSWClient(Config(csw_url="http://example.com/csw"))
-    xml_query = "<csw:GetRecords>...</csw:GetRecords>"
+    client = CSWClient(Config(csw_url="http://example.com/csw", chunk_size=50))
+    xml_query = (
+        '<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" '
+        'service="CSW" version="2.0.2" resultType="results" '
+        'outputSchema="http://www.isotc211.org/2005/gmd">'
+        '<csw:Query typeNames="csw:Record">'
+        "<csw:ElementSetName>full</csw:ElementSetName>"
+        "</csw:Query>"
+        "</csw:GetRecords>"
+    )
     records = list(client.get_records(xml_query=xml_query))
 
-    # Verify getrecords2 was called with xml argument
-    mock_csw_instance.getrecords2.assert_called_once_with(xml=xml_query)
+    mock_csw_instance.getrecords2.assert_called_once()
+    sent_xml = mock_csw_instance.getrecords2.call_args.kwargs["xml"]
+    assert 'startPosition="1"' in sent_xml
+    assert 'maxRecords="50"' in sent_xml
 
     assert len(records) == 1
     assert isinstance(records[0], InspireRecord)

--- a/middleware/inspire/tests/unit/test_harvester_comprehensive.py
+++ b/middleware/inspire/tests/unit/test_harvester_comprehensive.py
@@ -347,7 +347,7 @@ def test_get_records_by_xml(mock_csw_cls: MagicMock, mock_iso_record: MagicMock)
     mock_instance = MagicMock()
     mock_csw_cls.return_value = mock_instance
     mock_instance.records = {"uuid-123": mock_iso_record}
-    mock_instance.results = {"matches": 1}
+    mock_instance.results = {"matches": 1, "returned": 1, "nextrecord": 0}
 
     # Patch isinstance
     original_isinstance = isinstance
@@ -357,16 +357,24 @@ def test_get_records_by_xml(mock_csw_cls: MagicMock, mock_iso_record: MagicMock)
             return True
         return original_isinstance(obj, cls)
 
-    client = CSWClient(Config(csw_url="http://example.com/csw"))
+    xml_query = (
+        '<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" '
+        'service="CSW" version="2.0.2" resultType="results" '
+        'outputSchema="http://www.isotc211.org/2005/gmd">'
+        '<csw:Query typeNames="csw:Record">'
+        "<csw:ElementSetName>full</csw:ElementSetName>"
+        "</csw:Query>"
+        "</csw:GetRecords>"
+    )
+    client = CSWClient(Config(csw_url="http://example.com/csw", chunk_size=25))
     with patch("middleware.inspire.csw_client.isinstance", side_effect=mock_isinstance):
-        # Trigger XML path
-        results = list(client.get_records(xml_query="<Filter>...</Filter>"))
+        results = list(client.get_records(xml_query=xml_query))
 
     assert len(results) == 1
     mock_instance.getrecords2.assert_called()
-    # Check if xml was used in call args if possible, or just ensure it didn't crash
     kwargs = mock_instance.getrecords2.call_args.kwargs
     assert "xml" in kwargs
+    assert 'maxRecords="25"' in kwargs["xml"]
 
 
 def test_get_records_by_constraints(mock_csw_cls: MagicMock, mock_iso_record: MagicMock) -> None:

--- a/spec/principles.md
+++ b/spec/principles.md
@@ -62,15 +62,21 @@ closed, apply least privilege.
   (defined in `middleware.harvester.errors`).
 - Code quality gates: Ruff (lint + format), mypy, pylint, bandit, pytest —
   all must pass before merge. Every new feature requires matching tests.
-- **All quality tool invocations (VS Code, pre-commit, CI) must produce identical
-  results.** This is achieved by having each tool read its configuration exclusively
-  from a single shared config file — normally `pyproject.toml` (`[tool.ruff]`,
-  `[tool.mypy]`, `[tool.pylint.*]`). Tools that cannot be configured via
-  `pyproject.toml` (e.g. bandit) must have a dedicated config file (e.g. `.bandit`)
+- **All quality tool invocations (VS Code / Cursor, pre-commit, CI) must produce
+  identical results.** This is achieved by having each tool read its configuration
+  exclusively from a single shared config file — normally `pyproject.toml`
+  (`[tool.ruff]`, `[tool.mypy]`, `[tool.pylint.*]`). Tools that cannot be configured
+  via `pyproject.toml` (e.g. bandit) must have a dedicated config file (e.g. `.bandit`)
   shared by all invocations. Individual invocations must contain no extra CLI flags
   that override shared config; the only acceptable flags are those that cannot be
   expressed in a config file. The tool version used in every context must be the one
   locked in `uv.lock` — use `uv run <tool>` everywhere.
+  For type checking specifically: the merge gate is **mypy**
+  (`uv run mypy --config-file pyproject.toml middleware/`). The IDE must run the
+  same via `ms-python.mypy-type-checker` (see `.vscode/settings.json`: same binary,
+  same config file, same `middleware/` target, `reportingScope=workspace`).
+  cursorpyright / Pylance diagnostics are not a substitute and must not be treated
+  as “type check passed”.
 - No `noqa` / `type: ignore` suppressions unless technically unavoidable.
 - Validation belongs in Pydantic models where possible. Use `Literal` types or
   `@field_validator` to enforce valid values — a `ValidationError` triggers the


### PR DESCRIPTION
- Updated the `CSWClient` to support pagination for `xml_query`, allowing `startPosition` and `maxRecords` attributes to be rewritten per page.
- Improved documentation in `README.md` and `design.md` to clarify the behavior of `xml_query` with respect to pagination and record limits.
- Added unit tests to verify the correct handling of `maxRecords` and `startPosition` attributes, ensuring that invalid values are logged and default configurations are applied.
- Refactored related methods to maintain clarity and consistency in handling XML requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default harvest behavior for `xml_query` (full pagination vs one page) and mid-harvest error/retry semantics for ISO fetches; high test coverage but operators with complex XML filters may see different record counts until configs are adjusted.
> 
> **Overview**
> **CSW `xml_query` now harvests across pages** instead of sending one unpaged `GetRecords`. The filter/query body stays intact; each request uses a **deep copy** of the template with rewritten `startPosition` / `maxRecords`, ISO `outputSchema` forced to gmd on ISO fetches, and Dublin Core fallback using the same paging on its own copy. Invalid or non-CSW-root `GetRecords` XML raises **`ValueError` before `connect()`** (also for `get_record_count`).
> 
> **Paging and limits are split clearly:** XML `maxRecords` / `startPosition` override **page size** and **initial offset** when valid; config **`max_records`** caps **total successful records** across pages (all query modes). Oversized pages are trimmed via `_limit_page_to_max_records`, but **`RecordProcessingError` items on that page are still yielded**. Pagination advances using the **fetched** batch size when `nextrecord`/`returned` are missing, not the trimmed yield list.
> 
> **ISO fetch errors:** transient `OSError`/`TimeoutError` still become `CswConnectionError` for async retry; **`ValueError` from OWSLib now propagates unwrapped** (not retryable). Docs, example YAML comments, `Config` field descriptions, **AGENTS.md** / **spec/principles.md** mypy invocation, and **VS Code** mypy-type-checker settings are updated so IDE diagnostics match CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 719a8dcba7bd1e5e7020762377151ddcc0fb1038. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->